### PR TITLE
Use hashbrown maps & sets

### DIFF
--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -13,9 +13,9 @@ readme="README.md"
 glyph_brush_layout = { version = "0.1.1", path = "../glyph-brush-layout" }
 log = "0.4"
 ordered-float = "1"
-rustc-hash = "1"
 full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype" }
 seahash = "3"
+hashbrown = "0.1"
 
 [dev-dependencies]
 env_logger = { version = "0.6", default-features = false }

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -4,11 +4,10 @@ pub use self::builder::*;
 
 use super::*;
 use full_rusttype::gpu_cache::Cache;
+use hashbrown::hash_map::Entry;
 use log::error;
-use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, HashMap, HashSet},
     fmt,
     hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
     i32,
@@ -44,14 +43,14 @@ pub struct GlyphBrush<'font, H = DefaultSectionHasher> {
 
     // cache of section-layout hash -> computed glyphs, this avoid repeated glyph computation
     // for identical layout/sections common to repeated frame rendering
-    calculate_glyph_cache: FxHashMap<SectionHash, GlyphedSection<'font>>,
+    calculate_glyph_cache: hashbrown::HashMap<SectionHash, GlyphedSection<'font>>,
 
     // buffer of section-layout hashs (that must exist in the calculate_glyph_cache)
     // to be used on the next `process_queued` call
     section_buffer: Vec<SectionHash>,
 
     // Set of section hashs to keep in the glyph cache this frame even if they haven't been drawn
-    keep_in_cache: FxHashSet<SectionHash>,
+    keep_in_cache: hashbrown::HashSet<SectionHash>,
 
     // config
     cache_glyph_positioning: bool,
@@ -324,7 +323,7 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
     fn clear_section_buffer(&mut self) {
         if self.cache_glyph_positioning {
             // clear section_buffer & trim calculate_glyph_cache to active sections
-            let active: FxHashSet<_> = self
+            let active: hashbrown::HashSet<_> = self
                 .section_buffer
                 .drain(..)
                 .chain(self.keep_in_cache.drain())

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -1,4 +1,9 @@
-use super::*;
+use super::LastDrawInfo;
+use crate::{
+    DefaultSectionHasher, Font, FontId, GlyphBrush, SharedBytes,
+};
+use full_rusttype::gpu_cache::Cache;
+use std::hash::BuildHasher;
 
 /// Builder for a [`GlyphBrush`](struct.GlyphBrush.html).
 ///
@@ -186,8 +191,8 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
 
             last_draw: LastDrawInfo::default(),
             section_buffer: Vec::new(),
-            calculate_glyph_cache: HashMap::default(),
-            keep_in_cache: HashSet::default(),
+            calculate_glyph_cache: hashbrown::HashMap::default(),
+            keep_in_cache: hashbrown::HashSet::default(),
 
             cache_glyph_positioning: self.cache_glyph_positioning,
             cache_glyph_drawing: self.cache_glyph_drawing && self.cache_glyph_positioning,

--- a/glyph-brush/src/glyph_calculator.rs
+++ b/glyph-brush/src/glyph_calculator.rs
@@ -1,9 +1,8 @@
 use super::*;
 use full_rusttype::point;
-use rustc_hash::*;
+use hashbrown::hash_map::Entry;
 use std::{
     borrow::Cow,
-    collections::{hash_map::Entry, HashSet},
     fmt,
     hash::{BuildHasher, Hash, Hasher},
     i32, mem, slice,
@@ -120,7 +119,7 @@ pub struct GlyphCalculator<'font, H = DefaultSectionHasher> {
 
     // cache of section-layout hash -> computed glyphs, this avoid repeated glyph computation
     // for identical layout/sections common to repeated frame rendering
-    calculate_glyph_cache: Mutex<FxHashMap<u64, GlyphedSection<'font>>>,
+    calculate_glyph_cache: Mutex<hashbrown::HashMap<u64, GlyphedSection<'font>>>,
 
     section_hasher: H,
 }
@@ -136,7 +135,7 @@ impl<'font, H: BuildHasher + Clone> GlyphCalculator<'font, H> {
         GlyphCalculatorGuard {
             fonts: &self.fonts,
             glyph_cache: self.calculate_glyph_cache.lock().unwrap(),
-            cached: FxHashSet::default(),
+            cached: hashbrown::HashSet::default(),
             section_hasher: self.section_hasher.clone(),
         }
     }
@@ -152,8 +151,8 @@ impl<'font, H: BuildHasher + Clone> GlyphCalculator<'font, H> {
 /// [`GlyphCalculator`](struct.GlyphCalculator.html) scoped cache lock.
 pub struct GlyphCalculatorGuard<'brush, 'font: 'brush, H = DefaultSectionHasher> {
     fonts: &'brush Vec<Font<'font>>,
-    glyph_cache: MutexGuard<'brush, FxHashMap<u64, GlyphedSection<'font>>>,
-    cached: FxHashSet<u64>,
+    glyph_cache: MutexGuard<'brush, hashbrown::HashMap<u64, GlyphedSection<'font>>>,
+    cached: hashbrown::HashSet<u64>,
     section_hasher: H,
 }
 
@@ -228,7 +227,7 @@ impl<'font, H: BuildHasher> GlyphCruncher<'font> for GlyphCalculatorGuard<'_, 'f
 
 impl<H> Drop for GlyphCalculatorGuard<'_, '_, H> {
     fn drop(&mut self) {
-        let cached = mem::replace(&mut self.cached, HashSet::default());
+        let cached = mem::replace(&mut self.cached, hashbrown::HashSet::default());
         self.glyph_cache.retain(|key, _| cached.contains(key));
     }
 }


### PR DESCRIPTION
* Yields 1-1.04x speedup compared to the std/fx-hash

```
name                                                control ns/iter  change ns/iter  diff ns/iter  diff %  speedup 
continually_modify_bounds_of_1_of_3                 966,252          951,991              -14,261  -1.48%   x 1.01 
continually_modify_color_of_1_of_3                  907,074          897,520               -9,554  -1.05%   x 1.01 
continually_modify_end_text_of_1_of_3               908,699          908,033                 -666  -0.07%   x 1.00 
continually_modify_middle_text_of_1_of_3            905,590          898,657               -6,933  -0.77%   x 1.01 
continually_modify_position_of_1_of_3               903,670          895,687               -7,983  -0.88%   x 1.01 
continually_modify_start_text_of_1_of_3             915,927          912,720               -3,207  -0.35%   x 1.00 
no_cache_render_100_small_sections_fully            3,738,690        3,735,477             -3,213  -0.09%   x 1.00 
no_cache_render_1_large_section_partially           565,678          555,592              -10,086  -1.78%   x 1.02 
no_cache_render_3_medium_sections_fully             1,534,506        1,530,431             -4,075  -0.27%   x 1.00 
no_cache_render_v_bottom_1_large_section_partially  6,875,183        6,774,297           -100,886  -1.47%   x 1.01 
no_cache_render_v_center_1_large_section_partially  6,942,058        6,760,395           -181,663  -2.62%   x 1.03 
render_100_small_sections_fully                     18,108           17,389                  -719  -3.97%   x 1.04 
render_1_large_section_partially                    3,393            3,320                    -73  -2.15%   x 1.02 
render_3_medium_sections_fully                      1,264            1,251                    -13  -1.03%   x 1.01 
render_v_bottom_1_large_section_partially           3,400            3,324                    -76  -2.24%   x 1.02 
render_v_center_1_large_section_partially           3,391            3,324                    -67  -1.98%   x 1.02
```