### PR TITLE
Impl FontMap for AsRef instead of Index trait by default

### DIFF
--- a/glyph-brush-layout/src/font.rs
+++ b/glyph-brush-layout/src/font.rs
@@ -1,5 +1,4 @@
 use full_rusttype::Font;
-use std::ops;
 
 /// Id for a font
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default)]
@@ -12,10 +11,10 @@ pub trait FontMap<'font> {
 
 impl<'font, T> FontMap<'font> for T
 where
-    T: ops::Index<usize, Output = Font<'font>>,
+    T: AsRef<[Font<'font>]>,
 {
     #[inline]
     fn font(&self, i: FontId) -> &Font<'font> {
-        self.index(i.0)
+        &self.as_ref()[i.0]
     }
 }


### PR DESCRIPTION
As weird as it sounds, AsRef<[T]> is implemented in more
instances than Index<usize, Output=T> is:

* Vec<T> impls both
* [T; N] impls only AsRef<[T]>
* &[T; N] impls only AsRef<[T]>
* [T] impls both
* &[T] impls only AsRef<[T]>

Just compare [this](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=f59818ad69ec5e2ef42b34082aaa480f) to [this](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=2b416bb891a7e9acc81ff5ed9f1a46a4).

The language gives us an either-or choice between the two traits.
I think that impl'ing it by default for AsRef is the best solution.