### PR TITLE
Add `keep_cached` functions

### DIFF
--- a/gfx-glyph/src/lib.rs
+++ b/gfx-glyph/src/lib.rs
@@ -225,6 +225,31 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>, H: BuildHasher> GlyphBrush<'f
         self.glyph_brush.queue(section)
     }
 
+    /// Retains the section in the cache as if it had been used in the last draw-frame.
+    ///
+    /// Should not be necessary unless using multiple draws per frame with distinct transforms,
+    /// see [caching behaviour](#caching-behaviour).
+    #[inline]
+    pub fn keep_cached_custom_layout<'a, S, G>(&mut self, section: S, custom_layout: &G)
+    where
+        S: Into<Cow<'a, VariedSection<'a>>>,
+        G: GlyphPositioner,
+    {
+        self.glyph_brush.keep_cached_custom_layout(section, custom_layout)
+    }
+
+    /// Retains the section in the cache as if it had been used in the last draw-frame.
+    ///
+    /// Should not be necessary unless using multiple draws per frame with distinct transforms,
+    /// see [caching behaviour](#caching-behaviour).
+    #[inline]
+    pub fn keep_cached<'a, S>(&mut self, section: S)
+    where
+        S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        self.glyph_brush.keep_cached(section)
+    }
+
     /// Draws all queued sections onto a render target, applying a position transform (e.g.
     /// a projection).
     /// See [`queue`](struct.GlyphBrush.html#method.queue).

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -368,6 +368,39 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
         self.fonts.push(font_data);
         FontId(self.fonts.len() - 1)
     }
+
+    /// Retains the section in the cache as if it had been used in the last draw-frame.
+    ///
+    /// Should not generally be necessary, see [caching behaviour](#caching-behaviour).
+    pub fn keep_cached_custom_layout<'a, S, G>(&mut self, section: S, custom_layout: &G)
+    where
+        S: Into<Cow<'a, VariedSection<'a>>>,
+        G: GlyphPositioner,
+    {
+        if !self.cache_glyph_positioning {
+            return;
+        }
+        let section = section.into();
+        if cfg!(debug_assertions) {
+            for text in &section.text {
+                assert!(self.fonts.len() > text.font_id.0, "Invalid font id");
+            }
+        }
+        self.keep_in_cache
+            .insert(self.hash(&(section, custom_layout)));
+    }
+
+    /// Retains the section in the cache as if it had been used in the last draw-frame.
+    ///
+    /// Should not generally be necessary, see [caching behaviour](#caching-behaviour).
+    pub fn keep_cached<'a, S>(&mut self, section: S)
+    where
+        S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        let section = section.into();
+        let layout = section.layout;
+        self.keep_cached_custom_layout(section, &layout);
+    }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
Add `keep_cached` functions to glyph_brush & gfx_glyph.

These are not generally useful, but when using multiple transforms in gfx_glyph you may need to make multiple draws per frame and this allows a good way to optimise caching in that case.