### PR TITLE
Add GlyphBrush::queue_pre_positioned

### DIFF
--- a/gfx-glyph/CHANGELOG.md
+++ b/gfx-glyph/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 * Optimise vertex updating by declaring 'Dynamic' usage & using explicit update calls.
+* Add `GlyphBrush::queue_pre_positioned` and example *pre_positioned*.
+* Add `SectionGeometry`, `GlyphPositioner` to glyph_brush re-exported types.
 
 # 0.13.1
 * Add `GlyphBrush::keep_cached`.

--- a/gfx-glyph/examples/paragraph.rs
+++ b/gfx-glyph/examples/paragraph.rs
@@ -57,8 +57,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         )
         .unwrap();
 
-    let dejavu: &[u8] = include_bytes!("../../fonts/OpenSans-Light.ttf");
-    let mut glyph_brush = gfx_glyph::GlyphBrushBuilder::using_font_bytes(dejavu)
+    let font: &[u8] = include_bytes!("../../fonts/OpenSans-Light.ttf");
+    let mut glyph_brush = gfx_glyph::GlyphBrushBuilder::using_font_bytes(font)
         .initial_cache_size((1024, 1024))
         .build(factory.clone());
 

--- a/gfx-glyph/examples/pre_positioned.rs
+++ b/gfx-glyph/examples/pre_positioned.rs
@@ -1,0 +1,115 @@
+//!
+use gfx::{format, Device};
+use gfx_glyph::{rusttype, GlyphPositioner};
+use std::{env, error::Error};
+fn main() -> Result<(), Box<dyn Error>> {
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "gfx_glyph=warn");
+    }
+
+    env_logger::init();
+
+    if cfg!(target_os = "linux") {
+        // winit wayland is currently still wip
+        if env::var("WINIT_UNIX_BACKEND").is_err() {
+            env::set_var("WINIT_UNIX_BACKEND", "x11");
+        }
+        // disables vsync sometimes on x11
+        if env::var("vblank_mode").is_err() {
+            env::set_var("vblank_mode", "0");
+        }
+    }
+
+    if cfg!(debug_assertions) && env::var("yes_i_really_want_debug_mode").is_err() {
+        eprintln!(
+            "Note: Release mode will improve performance greatly.\n    \
+             e.g. use `cargo run --example pre_positioned --release`"
+        );
+    }
+
+    let mut events_loop = glutin::EventsLoop::new();
+    let title = "gfx_glyph example";
+    let window_builder = glutin::WindowBuilder::new()
+        .with_title(title)
+        .with_dimensions((1024, 576).into());
+    let context = glutin::ContextBuilder::new();
+    let (window, mut device, mut factory, mut main_color, mut main_depth) =
+        gfx_window_glutin::init::<format::Srgba8, format::DepthStencil>(
+            window_builder,
+            context,
+            &events_loop,
+        )
+        .unwrap();
+
+    let font: &[u8] = include_bytes!("../../fonts/OpenSans-Light.ttf");
+    let font = gfx_glyph::Font::from_bytes(font)?;
+    let mut glyph_brush = gfx_glyph::GlyphBrushBuilder::using_font(font.clone())
+        .initial_cache_size((1024, 1024))
+        .build(factory.clone());
+
+    let mut encoder: gfx::Encoder<_, _> = factory.create_command_buffer().into();
+
+    let mut running = true;
+    let mut loop_helper = spin_sleep::LoopHelper::builder().build_with_target_rate(250.0);
+
+    let (width, height, ..) = main_color.get_dimensions();
+    let (width, height) = (f32::from(width), f32::from(height));
+
+    let glyphs: Vec<_> = gfx_glyph::Layout::default().calculate_glyphs(
+        &[font],
+        &gfx_glyph::SectionGeometry {
+            screen_position: (0.0, 0.0),
+            bounds: (width, height),
+        },
+        &[gfx_glyph::SectionText {
+            text: include_str!("lipsum.txt"),
+            color: [0.8, 0.8, 0.8, 1.0],
+            scale: rusttype::Scale::uniform(30.0),
+            ..<_>::default()
+        }],
+    );
+
+    while running {
+        loop_helper.loop_start();
+
+        events_loop.poll_events(|event| {
+            use glutin::*;
+
+            if let Event::WindowEvent { event, .. } = event {
+                match event {
+                    WindowEvent::CloseRequested => running = false,
+                    WindowEvent::Resized(size) => {
+                        window.resize(size.to_physical(window.get_hidpi_factor()));
+                        gfx_window_glutin::update_views(&window, &mut main_color, &mut main_depth);
+                    }
+                    _ => {}
+                }
+            }
+        });
+
+        encoder.clear(&main_color, [0.02, 0.02, 0.02, 1.0]);
+
+        glyph_brush.queue_pre_positioned(
+            glyphs.clone(),
+            rusttype::Rect {
+                min: rusttype::point(0.0, 0.0),
+                max: rusttype::point(width, height),
+            },
+            0.0,
+        );
+
+        glyph_brush.draw_queued(&mut encoder, &main_color, &main_depth)?;
+
+        encoder.flush(&mut device);
+        window.swap_buffers()?;
+        device.cleanup();
+
+        if let Some(rate) = loop_helper.report_rate() {
+            window.set_title(&format!("{} - {:.0} FPS", title, rate));
+        }
+
+        loop_helper.loop_sleep();
+    }
+    println!();
+    Ok(())
+}

--- a/gfx-glyph/src/lib.rs
+++ b/gfx-glyph/src/lib.rs
@@ -223,6 +223,8 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>, H: BuildHasher> GlyphBrush<'f
         self.glyph_brush.queue(section)
     }
 
+    /// Queues pre-positioned glyphs to be processed by the next call of
+    /// [`draw_queued`](struct.GlyphBrush.html#method.draw_queued). Can be called multiple times.
     #[inline]
     pub fn queue_pre_positioned(
         &mut self,

--- a/gfx-glyph/src/lib.rs
+++ b/gfx-glyph/src/lib.rs
@@ -43,11 +43,12 @@ mod pipe;
 mod trace;
 
 pub use crate::builder::*;
+use glyph_brush::Color;
 pub use glyph_brush::{
     rusttype::{self, Font, Point, PositionedGlyph, Rect, Scale, SharedBytes},
     BuiltInLineBreaker, FontId, FontMap, GlyphCruncher, HorizontalAlign, Layout, LineBreak,
     LineBreaker, OwnedSectionText, OwnedVariedSection, PositionedGlyphIter, Section, SectionText,
-    VariedSection, VerticalAlign,
+    VariedSection, VerticalAlign, SectionGeometry, GlyphPositioner,
 };
 
 use crate::pipe::{glyph_pipe, GlyphVertex, RawAndFormat};
@@ -58,7 +59,7 @@ use gfx::{
     traits::FactoryExt,
 };
 use glyph_brush::{
-    rusttype::point, BrushAction, BrushError, DefaultSectionHasher, GlyphPositioner,
+    rusttype::point, BrushAction, BrushError, DefaultSectionHasher,
 };
 use log::{log_enabled, warn};
 use std::{
@@ -220,6 +221,16 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>, H: BuildHasher> GlyphBrush<'f
         S: Into<Cow<'a, VariedSection<'a>>>,
     {
         self.glyph_brush.queue(section)
+    }
+
+    #[inline]
+    pub fn queue_pre_positioned(
+        &mut self,
+        glyphs: Vec<(PositionedGlyph<'font>, Color, FontId)>,
+        bounds: Rect<f32>,
+        z: f32,
+    ) {
+        self.glyph_brush.queue_pre_positioned(glyphs, bounds, z)
     }
 
     /// Retains the section in the cache as if it had been used in the last draw-frame.

--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -16,7 +16,6 @@
 * Implement `Clone`, `PartialEq` for `BrushError`
 * Implement `Debug`, `Clone` for other public things.
 * Add `GlyphBrush::queue_pre_positioned` for fully custom glyph positioning.
-  This is currently not compatible with draw caching, so no `BrushAction::ReDraw`s will occur when using it.
 
 # 0.2.4
 * Add `GlyphBrush::keep_cached`.

--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Implement `PartialEq` for `*Section`s
 * Implement `Clone`, `PartialEq` for `BrushError`
 * Implement `Debug`, `Clone` for other public things.
+* Add `GlyphBrush::queue_pre_positioned` for fully custom glyph positioning.
+  This is currently not compatible with draw caching, so no `BrushAction::ReDraw`s will occur when using it.
 
 # 0.2.4
 * Add `GlyphBrush::keep_cached`.

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -196,6 +196,9 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
             cache_glyph_drawing: self.cache_glyph_drawing && self.cache_glyph_positioning,
 
             section_hasher: self.section_hasher,
+
+            pre_positioned: <_>::default(),
+            pre_positioning: false,
         }
     }
 }

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -197,8 +197,8 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
 
             section_hasher: self.section_hasher,
 
+            last_pre_positioned: <_>::default(),
             pre_positioned: <_>::default(),
-            pre_positioning: false,
         }
     }
 }

--- a/glyph-brush/src/glyph_calculator.rs
+++ b/glyph-brush/src/glyph_calculator.rs
@@ -339,6 +339,19 @@ pub(crate) struct GlyphedSection<'font> {
     pub z: f32,
 }
 
+impl<'a> PartialEq<GlyphedSection<'a>> for GlyphedSection<'a> {
+    fn eq(&self, other: &Self) -> bool {
+        self.bounds == other.bounds
+            && self.z == other.z
+            && self.glyphs.len() == other.glyphs.len()
+            && self
+                .glyphs
+                .iter()
+                .zip(other.glyphs.iter())
+                .all(|(l, r)| l.2 == r.2 && l.1 == r.1 && l.0.id() == r.0.id())
+    }
+}
+
 impl<'font> GlyphedSection<'font> {
     pub(crate) fn pixel_bounds(&self) -> Option<Rect<i32>> {
         let Self {


### PR DESCRIPTION
Allows fully custom glyph positioning that can't be achieve with a custom `GlyphPositioner`.

Closes #53