### PR TITLE
Optimise layout recalculation

### DIFF
--- a/glyph-brush-layout/CHANGELOG.md
+++ b/glyph-brush-layout/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Unreleased
-* Add `GlyphPositioner::recalculate_glyphs` with a default unoptimised implementation.
-* Optimise recalculate_glyphs for screen position changes with `GlyphChange::Geometry`.
-* Optimise recalculate_glyphs for single color changes with `GlyphChange::Color`.
-* Optimise recalculate_glyphs for alpha changes with `GlyphChange::Alpha`.
+* Add `GlyphPositioner::recalculate_glyphs` with a default unoptimised implementation. Custom layouts won't be broken by this change, but _will_ need to implement the new function to provide optimised behaviour.
+* Optimise built-in layout's recalculate_glyphs for screen position changes with `GlyphChange::Geometry`.
+* Optimise built-in layout's recalculate_glyphs for single color changes with `GlyphChange::Color`.
+* Optimise built-in layout's recalculate_glyphs for alpha changes with `GlyphChange::Alpha`.
 * Optimise layout re-positioning with `PositionedGlyph::set_position` usage.
 
 # 0.1.4

--- a/glyph-brush-layout/CHANGELOG.md
+++ b/glyph-brush-layout/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+* Add `GlyphPositioner::recalculate_glyphs` with a default unoptimised implementation.
+* Optimise recalculate_glyphs for screen position changes with `GlyphChange::Geometry`.
+* Optimise recalculate_glyphs for single color changes with `GlyphChange::Color`.
+* Optimise recalculate_glyphs for alpha changes with `GlyphChange::Alpha`.
+* Optimise layout re-positioning with `PositionedGlyph::set_position` usage.
+
 # 0.1.4
 * Implement `PartialEq` for `SectionGeometry` & `SectionText`.
 

--- a/glyph-brush-layout/Cargo.toml
+++ b/glyph-brush-layout/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme="README.md"
 
 [dependencies]
-full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype", git = "https://gitlab.redox-os.org/redox-os/rusttype" }
+full_rusttype = { version = "0.7.4", features = ["gpu_cache"], package = "rusttype" }
 xi-unicode = "0.1"
 
 [dev-dependencies]

--- a/glyph-brush-layout/Cargo.toml
+++ b/glyph-brush-layout/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme="README.md"
 
 [dependencies]
-full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype", path = "../../rusttype" }
+full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype", git = "https://gitlab.redox-os.org/redox-os/rusttype" }
 xi-unicode = "0.1"
 
 [dev-dependencies]

--- a/glyph-brush-layout/Cargo.toml
+++ b/glyph-brush-layout/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme="README.md"
 
 [dependencies]
-full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype" }
+full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype", path = "../../rusttype" }
 xi-unicode = "0.1"
 
 [dev-dependencies]

--- a/glyph-brush-layout/src/builtin.rs
+++ b/glyph-brush-layout/src/builtin.rs
@@ -428,6 +428,30 @@ mod layout_test {
         }};
     }
 
+    /// Compile test for trait stability
+    #[allow(unused)]
+    #[derive(Hash)]
+    enum SimpleCustomGlyphPositioner {}
+    impl GlyphPositioner for SimpleCustomGlyphPositioner {
+        fn calculate_glyphs<'font, F: FontMap<'font>>(
+            &self,
+            _: &F,
+            _: &SectionGeometry,
+            _: &[SectionText<'_>],
+        ) -> Vec<(PositionedGlyph<'font>, Color, FontId)> {
+            vec![]
+        }
+
+        /// Return a screen rectangle according to the requested render position and bounds
+        /// appropriate for the glyph layout.
+        fn bounds_rect(&self, _: &SectionGeometry) -> Rect<f32> {
+            Rect {
+                min: point(0.0, 0.0),
+                max: point(0.0, 0.0),
+            }
+        }
+    }
+
     #[test]
     fn zero_scale_glyphs() {
         let glyphs = Layout::default_single_line()

--- a/glyph-brush-layout/src/builtin.rs
+++ b/glyph-brush-layout/src/builtin.rs
@@ -808,10 +808,68 @@ mod layout_test {
             }],
         );
 
-        assert_glyph_order!(glyphs, "helloworld");
+        let recalc = Layout::default().recalculate_glyphs(
+            Cow::Owned(glyphs),
+            GlyphChange::Unknown,
+            &*FONT_MAP,
+            &SectionGeometry::default(),
+            &[SectionText {
+                text: "hello world",
+                scale: Scale::uniform(20.0),
+                ..SectionText::default()
+            }],
+        );
 
-        assert_relative_eq!(glyphs[0].0.position().x, 0.0);
-        let last_glyph = &glyphs.last().unwrap().0;
+        assert_glyph_order!(recalc, "helloworld");
+
+        assert_relative_eq!(recalc[0].0.position().x, 0.0);
+        let last_glyph = &recalc.last().unwrap().0;
+        assert!(
+            last_glyph.position().x > 0.0,
+            "unexpected last position {:?}",
+            last_glyph.position()
+        );
+    }
+
+    #[test]
+    fn recalculate_position() {
+        let geometry_1 = SectionGeometry {
+            screen_position: (0.0, 0.0),
+            ..<_>::default()
+        };
+
+        let glyphs = Layout::default().calculate_glyphs(
+            &*FONT_MAP,
+            &geometry_1,
+            &[SectionText {
+                text: "hello world",
+                scale: Scale::uniform(20.0),
+                ..SectionText::default()
+            }],
+        );
+
+        let original_y = glyphs[0].0.position().y;
+
+        let recalc = Layout::default().recalculate_glyphs(
+            Cow::Owned(glyphs),
+            GlyphChange::Geometry(geometry_1),
+            &*FONT_MAP,
+            &SectionGeometry {
+                screen_position: (0.0, 50.0),
+                ..geometry_1
+            },
+            &[SectionText {
+                text: "hello world",
+                scale: Scale::uniform(20.0),
+                ..SectionText::default()
+            }],
+        );
+
+        assert_glyph_order!(recalc, "helloworld");
+
+        assert_relative_eq!(recalc[0].0.position().x, 0.0);
+        assert_relative_eq!(recalc[0].0.position().y, original_y + 50.0);
+        let last_glyph = &recalc.last().unwrap().0;
         assert!(
             last_glyph.position().x > 0.0,
             "unexpected last position {:?}",

--- a/glyph-brush-layout/src/lib.rs
+++ b/glyph-brush-layout/src/lib.rs
@@ -113,5 +113,7 @@ pub trait GlyphPositioner: Hash {
 pub enum GlyphChange {
     /// Only the geometry has changed, contains the old geometry
     Geometry(SectionGeometry),
+    /// Only the colors have changed
+    Color,
     Unknown,
 }

--- a/glyph-brush-layout/src/lib.rs
+++ b/glyph-brush-layout/src/lib.rs
@@ -109,6 +109,7 @@ pub trait GlyphPositioner: Hash {
     }
 }
 
+// #[non_exhaustive] TODO use when stable
 #[derive(Debug)]
 pub enum GlyphChange {
     /// Only the geometry has changed, contains the old geometry
@@ -118,4 +119,6 @@ pub enum GlyphChange {
     /// Only the alpha has changed
     Alpha,
     Unknown,
+    #[doc(hidden)]
+    __Nonexhaustive,
 }

--- a/glyph-brush-layout/src/lib.rs
+++ b/glyph-brush-layout/src/lib.rs
@@ -115,5 +115,7 @@ pub enum GlyphChange {
     Geometry(SectionGeometry),
     /// Only the colors have changed
     Color,
+    /// Only the alpha has changed
+    Alpha,
     Unknown,
 }

--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Unreleased
+* Use queue call counting & fine grained hashing to match up previous calls with current calls figuring out what has changed allowing optimised use of `recalculate_glyphs` for fast layouts.
+  - Compute if just geometry (ie section position) has changed -> `GlyphChange::Geometry`.
+  - Compute if just color has changed -> `GlyphChange::Color`.
+  - Compute if just alpha has changed -> `GlyphChange::Alpha`.
+  ```
+  name                                   control ns/iter  change ns/iter  diff ns/iter   diff %  speedup
+  continually_modify_alpha_of_1_of_3     858,297          561,664             -296,633  -34.56%   x 1.53
+  continually_modify_color_of_1_of_3     870,442          558,456             -311,986  -35.84%   x 1.56
+  continually_modify_position_of_1_of_3  867,278          567,991             -299,287  -34.51%   x 1.53
+  ```
+
 # 0.3
 * Add `GlyphCruncher::fonts()` to common trait, hoisted from direct implementations. Add something like the following if you implement `GlyphCruncher`.
   ```rust

--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -13,7 +13,7 @@ readme="README.md"
 glyph_brush_layout = { version = "0.1.1", path = "../glyph-brush-layout" }
 log = "0.4.4"
 ordered-float = "1"
-full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype", path = "../../rusttype" }
+full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype", git = "https://gitlab.redox-os.org/redox-os/rusttype" }
 seahash = "3"
 hashbrown = "0.1"
 

--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -13,7 +13,7 @@ readme="README.md"
 glyph_brush_layout = { version = "0.1.1", path = "../glyph-brush-layout" }
 log = "0.4.4"
 ordered-float = "1"
-full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype" }
+full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype", path = "../../rusttype" }
 seahash = "3"
 hashbrown = "0.1"
 

--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -13,7 +13,7 @@ readme="README.md"
 glyph_brush_layout = { version = "0.1.1", path = "../glyph-brush-layout" }
 log = "0.4.4"
 ordered-float = "1"
-full_rusttype = { version = "0.7", features = ["gpu_cache"], package = "rusttype", git = "https://gitlab.redox-os.org/redox-os/rusttype" }
+full_rusttype = { version = "0.7.4", features = ["gpu_cache"], package = "rusttype" }
 seahash = "3"
 hashbrown = "0.1"
 

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -187,6 +187,7 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
             text: text_hash,
             text_geometry: text_geo_hash,
             full: full_hash,
+            geometry: SectionGeometry::from(section),
         }
     }
 
@@ -214,7 +215,7 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
                         Cow::Borrowed(&old_section.glyphs),
                         match section_hash.diff(*old_hash) {
                             SectionHashSimilarity::GeometryChange => {
-                                GlyphChange::Geometry(old_section.geometry)
+                                GlyphChange::Geometry(old_hash.geometry)
                             }
                             _ => GlyphChange::Unknown,
                         },
@@ -232,7 +233,6 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
                             layout.calculate_glyphs(&self.fonts, &geometry, &section.text)
                         }),
                         z: section.z,
-                        geometry,
                     },
                 );
             }
@@ -244,7 +244,6 @@ impl<'font, H: BuildHasher> GlyphBrush<'font, H> {
                     bounds: layout.bounds_rect(&geometry),
                     glyphs: layout.calculate_glyphs(&self.fonts, &geometry, &section.text),
                     z: section.z,
-                    geometry,
                 },
             );
         }
@@ -567,11 +566,12 @@ impl std::error::Error for BrushError {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy)]
 struct SectionHashDetail {
     text: SectionHash,
     text_geometry: SectionHash,
     full: SectionHash,
+    geometry: SectionGeometry,
 }
 
 #[derive(Debug)]

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -1,4 +1,3 @@
-use super::LastDrawInfo;
 use crate::{
     DefaultSectionHasher, Font, FontId, GlyphBrush, SharedBytes,
 };
@@ -187,10 +186,14 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
                 .position_tolerance(self.gpu_cache_position_tolerance)
                 .build(),
 
-            last_draw: LastDrawInfo::default(),
-            section_buffer: Vec::new(),
-            calculate_glyph_cache: hashbrown::HashMap::default(),
-            keep_in_cache: hashbrown::HashSet::default(),
+            last_draw: <_>::default(),
+            section_buffer: <_>::default(),
+            calculate_glyph_cache: <_>::default(),
+
+            last_frame_seq_id_sections: <_>::default(),
+            frame_seq_id_sections: <_>::default(),
+
+            keep_in_cache: <_>::default(),
 
             cache_glyph_positioning: self.cache_glyph_positioning,
             cache_glyph_drawing: self.cache_glyph_drawing && self.cache_glyph_positioning,

--- a/glyph-brush/src/glyph_calculator.rs
+++ b/glyph-brush/src/glyph_calculator.rs
@@ -179,7 +179,6 @@ impl<H: BuildHasher> GlyphCalculatorGuard<'_, '_, H> {
                 bounds: layout.bounds_rect(&geometry),
                 glyphs: layout.calculate_glyphs(self.fonts, &geometry, &section.text),
                 z: section.z,
-                geometry,
             });
         }
 
@@ -338,7 +337,6 @@ pub(crate) struct GlyphedSection<'font> {
     pub bounds: Rect<f32>,
     pub glyphs: Vec<(PositionedGlyph<'font>, Color, FontId)>,
     pub z: f32,
-    pub geometry: SectionGeometry,
 }
 
 impl<'a> PartialEq<GlyphedSection<'a>> for GlyphedSection<'a> {

--- a/glyph-brush/src/glyph_calculator.rs
+++ b/glyph-brush/src/glyph_calculator.rs
@@ -179,6 +179,7 @@ impl<H: BuildHasher> GlyphCalculatorGuard<'_, '_, H> {
                 bounds: layout.bounds_rect(&geometry),
                 glyphs: layout.calculate_glyphs(self.fonts, &geometry, &section.text),
                 z: section.z,
+                geometry,
             });
         }
 
@@ -337,6 +338,7 @@ pub(crate) struct GlyphedSection<'font> {
     pub bounds: Rect<f32>,
     pub glyphs: Vec<(PositionedGlyph<'font>, Color, FontId)>,
     pub z: f32,
+    pub geometry: SectionGeometry,
 }
 
 impl<'a> PartialEq<GlyphedSection<'a>> for GlyphedSection<'a> {

--- a/glyph-brush/src/section.rs
+++ b/glyph-brush/src/section.rs
@@ -98,7 +98,6 @@ impl Hash for VariedSection<'_> {
 
 #[inline]
 fn hash_section_text<H: Hasher>(state: &mut H, text: &[SectionText]) {
-    use ordered_float::OrderedFloat;
     for t in text {
         let SectionText {
             text,
@@ -272,16 +271,49 @@ pub(crate) struct HashableVariedSectionParts<'a> {
 }
 
 impl HashableVariedSectionParts<'_> {
+
     #[inline]
     pub fn hash_geometry<H: Hasher>(&self, state: &mut H) {
         self.geometry.hash(state);
     }
+
     #[inline]
     pub fn hash_z<H: Hasher>(&self, state: &mut H) {
         self.z.hash(state);
     }
+
     #[inline]
-    pub fn hash_text<H: Hasher>(&self, state: &mut H) {
-        hash_section_text(state, self.text);
+    pub fn hash_text_no_color<H: Hasher>(&self, state: &mut H) {
+        for t in self.text {
+            let SectionText {
+                text,
+                scale,
+                font_id,
+                ..
+            } = *t;
+
+            let ord_floats: &[OrderedFloat<_>] = &[
+                scale.x.into(),
+                scale.y.into(),
+            ];
+
+            (text, font_id, ord_floats).hash(state);
+        }
+    }
+
+    #[inline]
+    pub fn hash_color<H: Hasher>(&self, state: &mut H) {
+        for t in self.text {
+            let color = t.color;
+
+            let ord_floats: &[OrderedFloat<_>] = &[
+                color[0].into(),
+                color[1].into(),
+                color[2].into(),
+                color[3].into(),
+            ];
+
+            ord_floats.hash(state);
+        }
     }
 }

--- a/glyph-brush/src/section.rs
+++ b/glyph-brush/src/section.rs
@@ -302,6 +302,13 @@ impl HashableVariedSectionParts<'_> {
     }
 
     #[inline]
+    pub fn hash_alpha<H: Hasher>(&self, state: &mut H) {
+        for t in self.text {
+            OrderedFloat(t.color[3]).hash(state);
+        }
+    }
+
+    #[inline]
     pub fn hash_color<H: Hasher>(&self, state: &mut H) {
         for t in self.text {
             let color = t.color;
@@ -310,7 +317,6 @@ impl HashableVariedSectionParts<'_> {
                 color[0].into(),
                 color[1].into(),
                 color[2].into(),
-                color[3].into(),
             ];
 
             ord_floats.hash(state);

--- a/glyph-brush/src/section.rs
+++ b/glyph-brush/src/section.rs
@@ -1,4 +1,5 @@
 use super::{owned_section::*, *};
+use ordered_float::OrderedFloat;
 use std::{borrow::Cow, f32, hash::*};
 
 /// An object that contains all the info to render a varied section of text. That is one including
@@ -89,31 +90,37 @@ impl Hash for VariedSection<'_> {
 
         layout.hash(state);
 
-        for t in text {
-            let SectionText {
-                text,
-                scale,
-                color,
-                font_id,
-            } = *t;
-
-            let ord_floats: &[OrderedFloat<_>] = &[
-                scale.x.into(),
-                scale.y.into(),
-                color[0].into(),
-                color[1].into(),
-                color[2].into(),
-                color[3].into(),
-            ];
-
-            (text, font_id, ord_floats).hash(state);
-        }
+        hash_section_text(state, text);
 
         ord_floats.hash(state);
     }
 }
 
-impl VariedSection<'_> {
+#[inline]
+fn hash_section_text<H: Hasher>(state: &mut H, text: &[SectionText]) {
+    use ordered_float::OrderedFloat;
+    for t in text {
+        let SectionText {
+            text,
+            scale,
+            color,
+            font_id,
+        } = *t;
+
+        let ord_floats: &[OrderedFloat<_>] = &[
+            scale.x.into(),
+            scale.y.into(),
+            color[0].into(),
+            color[1].into(),
+            color[2].into(),
+            color[3].into(),
+        ];
+
+        (text, font_id, ord_floats).hash(state);
+    }
+}
+
+impl<'text> VariedSection<'text> {
     pub fn to_owned(&self) -> OwnedVariedSection {
         OwnedVariedSection {
             screen_position: self.screen_position,
@@ -121,6 +128,29 @@ impl VariedSection<'_> {
             z: self.z,
             layout: self.layout,
             text: self.text.iter().map(OwnedSectionText::from).collect(),
+        }
+    }
+
+    pub(crate) fn to_hashable_parts(&self) -> HashableVariedSectionParts<'_> {
+        let VariedSection {
+            screen_position: (screen_x, screen_y),
+            bounds: (bound_w, bound_h),
+            z,
+            ref text,
+            ..
+        } = *self;
+
+        let geometry = [
+            screen_x.into(),
+            screen_y.into(),
+            bound_w.into(),
+            bound_h.into(),
+        ];
+
+        HashableVariedSectionParts {
+            geometry,
+            z: z.into(),
+            text,
         }
     }
 }
@@ -232,5 +262,26 @@ impl<'a> From<Section<'a>> for Cow<'a, VariedSection<'a>> {
 impl<'a> From<&Section<'a>> for Cow<'a, VariedSection<'a>> {
     fn from(section: &Section<'a>) -> Self {
         Cow::Owned(VariedSection::from(section))
+    }
+}
+
+pub(crate) struct HashableVariedSectionParts<'a> {
+    geometry: [OrderedFloat<f32>; 4],
+    z: OrderedFloat<f32>,
+    text: &'a [SectionText<'a>],
+}
+
+impl HashableVariedSectionParts<'_> {
+    #[inline]
+    pub fn hash_geometry<H: Hasher>(&self, state: &mut H) {
+        self.geometry.hash(state);
+    }
+    #[inline]
+    pub fn hash_z<H: Hasher>(&self, state: &mut H) {
+        self.z.hash(state);
+    }
+    #[inline]
+    pub fn hash_text<H: Hasher>(&self, state: &mut H) {
+        hash_section_text(state, self.text);
     }
 }


### PR DESCRIPTION
This pr aims to improve performance in common situations where the layout cache becomes invalid. These include alpha & color changes, like fading out, and position changes like a simple scrolling mechanism. As layout is generally the most expensive operation optimisations here are desired.

# glyph_brush_layout
* Add `GlyphPositioner::recalculate_glyphs` with a default unoptimised implementation. Custom layouts won't be broken by this change, but _will_ need to implement the new function to provide optimised behaviour.
* Optimise built-in layout's recalculate_glyphs for screen position changes with `GlyphChange::Geometry`.
* Optimise built-in layout's recalculate_glyphs for single color changes with `GlyphChange::Color`.
* Optimise built-in layout's recalculate_glyphs for alpha changes with `GlyphChange::Alpha`.
* Optimise layout re-positioning with `PositionedGlyph::set_position` usage.

# glyph_brush
* Use queue call counting & fine grained hashing to match up previous calls with current calls figuring out what has changed allowing optimised use of `recalculate_glyphs` for fast layouts.
  - Compute if just geometry (ie section position) has changed -> `GlyphChange::Geometry`.
  - Compute if just color has changed -> `GlyphChange::Color`.
  - Compute if just alpha has changed -> `GlyphChange::Alpha`.

# Benchmarks
A big **1.5x** speedup can be observed for single color, alpha and position changes as full layout calculation for the changed section can be avoided. Other minor changes have yielded small improvements too.

```
name                                                control ns/iter  change ns/iter  diff ns/iter   diff %  speedup 
continually_modify_alpha_of_1_of_3                  858,297          561,664             -296,633  -34.56%   x 1.53 
continually_modify_bounds_of_1_of_3                 870,876          865,655               -5,221   -0.60%   x 1.01 
continually_modify_color_of_1_of_3                  870,442          558,456             -311,986  -35.84%   x 1.56 
continually_modify_end_text_of_1_of_3               865,359          861,083               -4,276   -0.49%   x 1.00 
continually_modify_middle_text_of_1_of_3            868,600          859,920               -8,680   -1.00%   x 1.01 
continually_modify_position_of_1_of_3               867,278          567,991             -299,287  -34.51%   x 1.53 
continually_modify_start_text_of_1_of_3             885,149          869,070              -16,079   -1.82%   x 1.02 
no_cache_render_100_small_sections_fully            3,651,486        3,615,537            -35,949   -0.98%   x 1.01 
no_cache_render_1_large_section_partially           552,719          545,451               -7,268   -1.31%   x 1.01 
no_cache_render_3_medium_sections_fully             1,506,003        1,485,978            -20,025   -1.33%   x 1.01 
no_cache_render_v_bottom_1_large_section_partially  6,987,923        6,743,719           -244,204   -3.49%   x 1.04 
no_cache_render_v_center_1_large_section_partially  6,964,006        6,698,045           -265,961   -3.82%   x 1.04 
render_100_small_sections_fully                     17,865           16,832                -1,033   -5.78%   x 1.06 
render_1_large_section_partially                    3,165            3,112                    -53   -1.67%   x 1.02 
render_3_medium_sections_fully                      1,151            1,076                    -75   -6.52%   x 1.07 
render_v_bottom_1_large_section_partially           3,167            3,115                    -52   -1.64%   x 1.02 
render_v_center_1_large_section_partially           3,169            3,114                    -55   -1.74%   x 1.02 
```