### PR TITLE
Cache vertex generation per section

### DIFF
--- a/gfx-glyph/src/lib.rs
+++ b/gfx-glyph/src/lib.rs
@@ -142,7 +142,7 @@ pub struct GlyphBrush<'font, R: gfx::Resources, F: gfx::Factory<R>, H = DefaultS
     factory: F,
     program: gfx::handle::Program<R>,
     draw_cache: Option<DrawnGlyphBrush<R>>,
-    glyph_brush: glyph_brush::GlyphBrush<'font, H>,
+    glyph_brush: glyph_brush::GlyphBrush<'font, GlyphVertex, H>,
 
     // config
     depth_test: gfx::state::Depth,

--- a/glyph-brush-layout/Cargo.toml
+++ b/glyph-brush-layout/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme="README.md"
 
 [dependencies]
-full_rusttype = { version = "0.7.4", features = ["gpu_cache"], package = "rusttype" }
+full_rusttype = { version = "0.7.4", features = ["gpu_cache"], package = "rusttype", git = "https://gitlab.redox-os.org/redox-os/rusttype" }
 xi-unicode = "0.1"
 
 [dev-dependencies]

--- a/glyph-brush-layout/Cargo.toml
+++ b/glyph-brush-layout/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 readme="README.md"
 
 [dependencies]
-full_rusttype = { version = "0.7.4", features = ["gpu_cache"], package = "rusttype", git = "https://gitlab.redox-os.org/redox-os/rusttype" }
+full_rusttype = { version = "0.7.4", features = ["gpu_cache"], package = "rusttype" }
 xi-unicode = "0.1"
 
 [dev-dependencies]

--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -3,12 +3,18 @@
   - Compute if just geometry (ie section position) has changed -> `GlyphChange::Geometry`.
   - Compute if just color has changed -> `GlyphChange::Color`.
   - Compute if just alpha has changed -> `GlyphChange::Alpha`.
+
+  Provides much faster re-layout performance in these common change scenarios.
+* `GlyphBrush` now generates & caches vertices avoiding regeneration of individual unchanged sections, when another section change forces regeneration of the complete vertex array. The user vertex type `V` is now in the struct signature.
+  ```rust
+  pub struct DownstreamGlyphBrush<'font, H = DefaultSectionHasher> {
+      // previously: glyph_brush::GlyphBrush<'font, H>,
+      inner: glyph_brush::GlyphBrush<'font, DownstreamGlyphVertex, H>,
+      ...
+  }
   ```
-  name                                   control ns/iter  change ns/iter  diff ns/iter   diff %  speedup
-  continually_modify_alpha_of_1_of_3     858,297          561,664             -296,633  -34.56%   x 1.53
-  continually_modify_color_of_1_of_3     870,442          558,456             -311,986  -35.84%   x 1.56
-  continually_modify_position_of_1_of_3  867,278          567,991             -299,287  -34.51%   x 1.53
-  ```
+
+These changes result in a big performance improvement for changes to sections amongst other unchanging sections, which is a fairly common thing to want to do. Fully cached (everything unchanging) & worst-case (everything changing/new) are not significantly affected.
 
 # 0.3
 * Add `GlyphCruncher::fonts()` to common trait, hoisted from direct implementations. Add something like the following if you implement `GlyphCruncher`.

--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -13,7 +13,7 @@ readme="README.md"
 glyph_brush_layout = { version = "0.1.1", path = "../glyph-brush-layout" }
 log = "0.4.4"
 ordered-float = "1"
-full_rusttype = { version = "0.7.4", features = ["gpu_cache"], package = "rusttype" }
+full_rusttype = { version = "0.7.4", features = ["gpu_cache"], package = "rusttype", git = "https://gitlab.redox-os.org/redox-os/rusttype" }
 seahash = "3"
 hashbrown = "0.1"
 

--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -13,7 +13,7 @@ readme="README.md"
 glyph_brush_layout = { version = "0.1.1", path = "../glyph-brush-layout" }
 log = "0.4.4"
 ordered-float = "1"
-full_rusttype = { version = "0.7.4", features = ["gpu_cache"], package = "rusttype", git = "https://gitlab.redox-os.org/redox-os/rusttype" }
+full_rusttype = { version = "0.7.5", features = ["gpu_cache"], package = "rusttype" }
 seahash = "3"
 hashbrown = "0.1"
 

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -1,6 +1,4 @@
-use crate::{
-    DefaultSectionHasher, Font, FontId, GlyphBrush, SharedBytes,
-};
+use crate::{DefaultSectionHasher, Font, FontId, GlyphBrush, SharedBytes};
 use full_rusttype::gpu_cache::Cache;
 use std::hash::BuildHasher;
 
@@ -9,10 +7,12 @@ use std::hash::BuildHasher;
 /// # Example
 ///
 /// ```no_run
-/// use glyph_brush::GlyphBrushBuilder;
+/// use glyph_brush::{GlyphBrush, GlyphBrushBuilder};
+/// # type Vertex = ();
 ///
 /// let dejavu: &[u8] = include_bytes!("../../../fonts/DejaVuSans.ttf");
-/// let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(dejavu).build();
+/// let mut glyph_brush: GlyphBrush<'_, Vertex> =
+///     GlyphBrushBuilder::using_font_bytes(dejavu).build();
 /// ```
 pub struct GlyphBrushBuilder<'a, H = DefaultSectionHasher> {
     pub font_data: Vec<Font<'a>>,
@@ -175,7 +175,7 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
     }
 
     /// Builds a `GlyphBrush` using the input gfx factory
-    pub fn build(self) -> GlyphBrush<'a, H> {
+    pub fn build<V: Clone + 'static>(self) -> GlyphBrush<'a, V, H> {
         let (cache_width, cache_height) = self.initial_cache_size;
 
         GlyphBrush {


### PR DESCRIPTION
`GlyphBrush` now generates & caches vertices avoiding regeneration of individual unchanged sections, when another section change forces regeneration of the complete vertex array. The user vertex type `V` is now in the struct signature.
  ```rust
  pub struct DownstreamGlyphBrush<'font, H = DefaultSectionHasher> {
      // previously: glyph_brush::GlyphBrush<'font, H>,
      inner: glyph_brush::GlyphBrush<'font, DownstreamGlyphVertex, H>,
      ...
  }
  ```

These changes result in a big performance improvement for changes to sections amongst other unchanging sections, which is a fairly common thing to want to do. Fully cached (everything unchanging) & worst-case (everything changing/new) are not significantly affected.

Benching from current release _(so this also shows #56 optimisation in addition to this change)_:
```
name                                      control ns/iter  change ns/iter  diff ns/iter   diff %  speedup 
continually_modify_alpha_of_1_of_3        854,554          349,165             -505,389  -59.14%   x 2.45 
continually_modify_bounds_of_1_of_3       865,162          643,341             -221,821  -25.64%   x 1.34 
continually_modify_color_of_1_of_3        855,189          344,501             -510,688  -59.72%   x 2.48 
continually_modify_end_text_of_1_of_3     857,913          647,491             -210,422  -24.53%   x 1.32 
continually_modify_middle_text_of_1_of_3  856,383          642,055             -214,328  -25.03%   x 1.33 
continually_modify_position_of_1_of_3     866,298          355,794             -510,504  -58.93%   x 2.43 
continually_modify_start_text_of_1_of_3   872,081          654,887             -217,194  -24.91%   x 1.33
no_cache_render_3_medium_sections_fully   1,480,556        1,500,286             19,730    1.33%   x 0.99
render_3_medium_sections_fully            1,136            1,066                    -70   -6.16%   x 1.07
```

~Note: Requires a new rusttype release~, updates rusttype to `0.7.5`.