### PR TITLE
Switch to xxHash as default section hasher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,23 @@ matrix:
   allow_failures:
   - os: osx
     rust: nightly
+  include:
+  # test 32-bit
+  - name: "i686-unknown-linux-musl"
+    env: TARGET=i686-unknown-linux-musl
+    addons:
+      apt:
+        packages:
+        - musl-gcc
   fast_finish: true
 os:
 - linux
 - osx
 script:
 - if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-    cargo build --all-features --all-targets;
+    cargo test --all --all-targets;
+  elif [ -n "$TARGET" ]; then
+    rustup target add "$TARGET" && cargo test --all --target "$TARGET";
+  else
+    cargo test --all;
   fi
-- if [ "$TRAVIS_RUST_VERSION" == "nightly" ]; then
-    cargo test --benches;
-  fi
-- cargo test --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ matrix:
     addons:
       apt:
         packages:
-        - musl-gcc
+        - gcc-multilib
+        - musl-tools
   fast_finish: true
 os:
 - linux

--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Change default section hasher to xxHash as seahash has been shown to collide easily in 32bit environments.
+
 # 0.4
 * Use queue call counting & fine grained hashing to match up previous calls with current calls figuring out what has changed allowing optimised use of `recalculate_glyphs` for fast layouts.
   - Compute if just geometry (ie section position) has changed -> `GlyphChange::Geometry`.

--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -14,8 +14,8 @@ glyph_brush_layout = { version = "0.1.5", path = "../glyph-brush-layout" }
 log = "0.4.4"
 ordered-float = "1"
 full_rusttype = { version = "0.7.5", features = ["gpu_cache"], package = "rusttype" }
-seahash = "3"
 hashbrown = "0.1"
+twox-hash = "1"
 
 [dev-dependencies]
 env_logger = { version = "0.6", default-features = false }

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -8,15 +8,12 @@ use log::error;
 use std::{
     borrow::Cow,
     fmt,
-    hash::{BuildHasher, BuildHasherDefault, Hash, Hasher},
+    hash::{BuildHasher, Hash, Hasher},
     i32, mem,
 };
 
 /// A hash of `Section` data
 type SectionHash = u64;
-
-/// A "practically collision free" `Section` hasher
-type DefaultSectionHasher = BuildHasherDefault<seahash::SeaHasher>;
 
 /// Object allowing glyph drawing, containing cache state. Manages glyph positioning cacheing,
 /// glyph draw caching & efficient GPU texture cache updating.

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -148,14 +148,14 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
     ///
     /// This hasher is used to distinguish sections, rather than for hashmap internal use.
     ///
-    /// Defaults to [seahash](https://docs.rs/seahash).
+    /// Defaults to [xxHash](https://docs.rs/twox-hash).
     ///
     /// # Example
     /// ```no_run
     /// # use glyph_brush::GlyphBrushBuilder;
     /// # fn main() {
     /// # let some_font: &[u8] = include_bytes!("../../../fonts/DejaVuSans.ttf");
-    /// # type SomeOtherBuildHasher = ::std::hash::BuildHasherDefault<seahash::SeaHasher>;
+    /// # type SomeOtherBuildHasher = glyph_brush::DefaultSectionHasher;
     /// GlyphBrushBuilder::using_font_bytes(some_font)
     ///     .section_hasher(SomeOtherBuildHasher::default())
     ///     // ...

--- a/glyph-brush/src/lib.rs
+++ b/glyph-brush/src/lib.rs
@@ -42,7 +42,33 @@ pub use crate::{glyph_brush::*, glyph_calculator::*, owned_section::*, section::
 pub use glyph_brush_layout::*;
 
 use glyph_brush_layout::rusttype::*;
-use std::hash::BuildHasherDefault;
 
 /// A "practically collision free" `Section` hasher
-pub type DefaultSectionHasher = BuildHasherDefault<seahash::SeaHasher>;
+pub type DefaultSectionHasher = twox_hash::RandomXxHashBuilder;
+
+#[test]
+fn default_section_hasher() {
+    use std::hash::{BuildHasher, Hash, Hasher};
+
+    let section_a = Section {
+        text: "Hovered Tile: Some((0, 0))",
+        screen_position: (5.0, 60.0),
+        scale: Scale { x: 20.0, y: 20.0 },
+        color: [1.0, 1.0, 1.0, 1.0],
+        ..<_>::default()
+    };
+    let section_b = Section {
+        text: "Hovered Tile: Some((1, 0))",
+        screen_position: (5.0, 60.0),
+        scale: Scale { x: 20.0, y: 20.0 },
+        color: [1.0, 1.0, 1.0, 1.0],
+        ..<_>::default()
+    };
+    let hash = |s: &Section| {
+        let s: VariedSection = s.into();
+        let mut hasher = DefaultSectionHasher::default().build_hasher();
+        s.hash(&mut hasher);
+        hasher.finish()
+    };
+    assert_ne!(hash(&section_a), hash(&section_b));
+}


### PR DESCRIPTION
After a trivial test case caused seahash collisions in 32bit environments it seems better to switch back to xxHash which performs well anyway.

This results in a performance regression for small sections and an improvement for large. Hash performance is still fast enough that it's mostly irrelevant. Collisions are deadly though.
```
name                                       control ns/iter  change ns/iter  diff ns/iter   diff %  speedup 
render_100_small_sections_fully            16,675           24,235                 7,560   45.34%   x 0.69 
render_1_large_section_partially           3,255            2,069                 -1,186  -36.44%   x 1.57 
render_3_medium_sections_fully             1,068            1,095                     27    2.53%   x 0.98 
render_v_bottom_1_large_section_partially  3,251            2,066                 -1,185  -36.45%   x 1.57 
render_v_center_1_large_section_partially  3,254            2,065                 -1,189  -36.54%   x 1.58 
```

Also added 32-bit testing and a new test that seahash fails.

Should fix #58 