### PR TITLE
WIP: Remove screen size dependency

### DIFF
--- a/gfx-glyph/CHANGELOG.md
+++ b/gfx-glyph/CHANGELOG.md
@@ -1,3 +1,15 @@
+# Unreleased
+* Update glyph_brush -> `0.5`.
+* **Breaking:** `draw_queued_with_transform` usages are now expected to provide the orthographic projection, whereas before this projection was pre-baked. The shader also now inverts the y-axis to be more in-line with other APIs. Previous usages can be technically converted with:
+ ```rust
+ // v0.14
+ glyph_brush.draw_queued_with_transform(custom_transform, ...);
+
+ // v0.15
+ glyph_brush.draw_queued_with_transform(invert_y * custom_transform * gfx_glyph::default_transform(&gfx_color), ...);
+ ```
+ The new style allows easier pre-projection transformations, like rotation, as before only post-projection transforms were possible. `draw_queued` usage is unchanged, it now internally uses `gfx_glyph::default_transform`.
+
 # 0.14.1
 * Enlarge textures within `GL_MAX_TEXTURE_SIZE` if possible.
 

--- a/gfx-glyph/examples/paragraph.rs
+++ b/gfx-glyph/examples/paragraph.rs
@@ -231,9 +231,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         let offset = Matrix4::from_translation(Vector3::new(-width / 2.0, -height / 2.0, 0.0));
         let rotation =
             offset.inverse_transform().unwrap() * Matrix4::from_angle_z(Rad(angle)) * offset;
-;
+
         // Projection
-        let projection = cgmath::ortho(0.0, width, 0.0, height, 1.0, -1.0);
+        let projection = cgmath::ortho(0.0, width, height, 0.0, 1.0, -1.0);
 
         // Here an example transform is used as a cheap zoom out (controlled with ctrl-scroll)
         let zoom = Matrix4::from_scale(zoom);

--- a/gfx-glyph/examples/paragraph.rs
+++ b/gfx-glyph/examples/paragraph.rs
@@ -232,8 +232,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         let rotation =
             offset.inverse_transform().unwrap() * Matrix4::from_angle_z(Rad(angle)) * offset;
 
-        // Projection
-        let projection = cgmath::ortho(0.0, width, height, 0.0, 1.0, -1.0);
+        // Default projection
+        let projection: Matrix4<f32> = gfx_glyph::default_transform(&main_color).into();
 
         // Here an example transform is used as a cheap zoom out (controlled with ctrl-scroll)
         let zoom = Matrix4::from_scale(zoom);

--- a/gfx-glyph/src/lib.rs
+++ b/gfx-glyph/src/lib.rs
@@ -277,9 +277,9 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>, H: BuildHasher> GlyphBrush<'f
 
         let projection = [
             [2.0 / width as f32, 0.0, 0.0, 0.0],
-            [0.0, 2.0 / height as f32, 0.0, 0.0],
+            [0.0, -2.0 / height as f32, 0.0, 0.0],
             [0.0, 0.0, 1.0, 0.0],
-            [-1.0, -1.0, 0.0, 1.0],
+            [-1.0, 1.0, 0.0, 1.0],
         ];
 
         self.draw_queued_with_transform(projection, encoder, target, depth_target)

--- a/gfx-glyph/src/lib.rs
+++ b/gfx-glyph/src/lib.rs
@@ -284,7 +284,7 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>, H: BuildHasher> GlyphBrush<'f
 
     /// Draws all queued sections onto a render target, applying the default transform.
     /// See [`queue`](struct.GlyphBrush.html#method.queue).
-    /// See [`default_transform`](fn.default_transform.html)
+    /// See [`default_transform`](fn.default_transform.html).
     ///
     /// Trims the cache, see [caching behaviour](#caching-behaviour).
     ///
@@ -309,6 +309,7 @@ impl<'font, R: gfx::Resources, F: gfx::Factory<R>, H: BuildHasher> GlyphBrush<'f
     /// Draws all queued sections onto a render target, applying a position transform (e.g.
     /// a projection).
     /// See [`queue`](struct.GlyphBrush.html#method.queue).
+    /// See [`default_transform`](fn.default_transform.html).
     ///
     /// Trims the cache, see [caching behaviour](#caching-behaviour).
     ///

--- a/gfx-glyph/src/pipe.rs
+++ b/gfx-glyph/src/pipe.rs
@@ -124,3 +124,35 @@ impl<R> RawAndFormat for (&R, Format) {
         self.1
     }
 }
+
+pub trait IntoDimensions {
+    /// Returns (width, height)
+    fn into_dimensions(self) -> (f32, f32);
+}
+
+impl<R, CV> IntoDimensions for &CV
+where
+    R: Resources,
+    CV: RawAndFormat<Raw = RawRenderTargetView<R>>,
+{
+    #[inline]
+    fn into_dimensions(self) -> (f32, f32) {
+        let (width, height, ..) = self.as_raw().get_dimensions();
+        (f32::from(width), f32::from(height))
+    }
+}
+
+impl<T: Into<f32>> IntoDimensions for [T; 2] {
+    #[inline]
+    fn into_dimensions(self) -> (f32, f32) {
+        let [w, h] = self;
+        (w.into(), h.into())
+    }
+}
+
+impl<T: Into<f32>> IntoDimensions for (T, T) {
+    #[inline]
+    fn into_dimensions(self) -> (f32, f32) {
+        (self.0.into(), self.1.into())
+    }
+}

--- a/gfx-glyph/src/shader/vert.glsl
+++ b/gfx-glyph/src/shader/vert.glsl
@@ -11,13 +11,6 @@ in vec4 color;
 out vec2 f_tex_pos;
 out vec4 f_color;
 
-const mat4 INVERT_Y_AXIS = mat4(
-    vec4(1.0, 0.0, 0.0, 0.0),
-    vec4(0.0, -1.0, 0.0, 0.0),
-    vec4(0.0, 0.0, 1.0, 0.0),
-    vec4(0.0, 0.0, 0.0, 1.0)
-);
-
 // generate positional data based on vertex ID
 void main() {
     vec2 pos = vec2(0.0);
@@ -46,5 +39,5 @@ void main() {
     }
 
     f_color = color;
-    gl_Position = INVERT_Y_AXIS * transform * vec4(pos, left_top.z, 1.0);
+    gl_Position = transform * vec4(pos, left_top.z, 1.0);
 }

--- a/gfx-glyph/src/shader/vert.glsl
+++ b/gfx-glyph/src/shader/vert.glsl
@@ -11,6 +11,13 @@ in vec4 color;
 out vec2 f_tex_pos;
 out vec4 f_color;
 
+const mat4 INVERT_Y_AXIS = mat4(
+    vec4(1.0, 0.0, 0.0, 0.0),
+    vec4(0.0, -1.0, 0.0, 0.0),
+    vec4(0.0, 0.0, 1.0, 0.0),
+    vec4(0.0, 0.0, 0.0, 1.0)
+);
+
 // generate positional data based on vertex ID
 void main() {
     vec2 pos = vec2(0.0);
@@ -39,5 +46,5 @@ void main() {
     }
 
     f_color = color;
-    gl_Position = transform * vec4(pos, left_top.z, 1.0);
+    gl_Position = INVERT_Y_AXIS * transform * vec4(pos, left_top.z, 1.0);
 }

--- a/gfx-glyph/src/shader/vert.glsl
+++ b/gfx-glyph/src/shader/vert.glsl
@@ -1,5 +1,12 @@
 #version 150
 
+const mat4 INVERT_Y_AXIS = mat4(
+    vec4(1.0, 0.0, 0.0, 0.0),
+    vec4(0.0, -1.0, 0.0, 0.0),
+    vec4(0.0, 0.0, 1.0, 0.0),
+    vec4(0.0, 0.0, 0.0, 1.0)
+);
+
 uniform mat4 transform;
 
 in vec3 left_top;
@@ -39,5 +46,5 @@ void main() {
     }
 
     f_color = color;
-    gl_Position = transform * vec4(pos, left_top.z, 1.0);
+    gl_Position = INVERT_Y_AXIS * transform * vec4(pos, left_top.z, 1.0);
 }

--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+* Removed screen dimensions from `process_queued` arguments. `to_vertex` function arguments also no longer include screen dimensions. Vertices should now be given pixel coordinates and use an appropriate projection matrix as a transform.
+
+ This approach simplifies glyph_brush code & allows the vertex cache to survive screen resolution changes. It also makes pre-projection custom transforms much easier to use. See usage changes in the opengl example & gfx_glyph.
+
 # 0.4.3
 * Fix cached vertices erroneously remaining valid after screen dimension change.
 * Update hashbrown -> `0.3`.

--- a/glyph-brush/examples/opengl.rs
+++ b/glyph-brush/examples/opengl.rs
@@ -105,8 +105,8 @@ fn main() -> Res<()> {
         let transform = ortho(
             0.0,
             dimensions.width as _,
-            dimensions.height as _,
             0.0,
+            dimensions.height as _,
             1.0,
             -1.0,
         );
@@ -174,8 +174,8 @@ fn main() -> Res<()> {
                                 let transform = ortho(
                                     0.0,
                                     dimensions.width as _,
-                                    dimensions.height as _,
                                     0.0,
+                                    dimensions.height as _,
                                     1.0,
                                     -1.0,
                                 );

--- a/glyph-brush/examples/opengl.rs
+++ b/glyph-brush/examples/opengl.rs
@@ -79,7 +79,12 @@ fn main() -> Res<()> {
     let mut vbo = 0;
     let mut texture = GlGlyphTexture::new(glyph_brush.texture_dimensions());
 
-    unsafe {
+    let mut dimensions = window
+        .get_inner_size()
+        .ok_or("get_inner_size = None")?
+        .to_physical(window.get_hidpi_factor());
+
+    let transform_uniform = unsafe {
         // Create Vertex Array Object
         gl::GenVertexArrays(1, &mut vao);
         gl::BindVertexArray(vao);
@@ -93,6 +98,20 @@ fn main() -> Res<()> {
         gl::BindFragDataLocation(program, 0, CString::new("out_color")?.as_ptr());
 
         // Specify the layout of the vertex data
+        let uniform = gl::GetUniformLocation(program, CString::new("transform")?.as_ptr());
+        if uniform < 0 {
+            return Err(format!("GetUniformLocation(\"transform\") -> {}", uniform).into());
+        }
+        let transform = ortho(
+            0.0,
+            dimensions.width as _,
+            dimensions.height as _,
+            0.0,
+            1.0,
+            -1.0,
+        );
+        gl::UniformMatrix4fv(uniform, 1, 0, transform.as_ptr());
+
         let mut offset = 0;
         for (v_field, float_count) in &[
             ("left_top", 3),
@@ -125,7 +144,9 @@ fn main() -> Res<()> {
         // Use srgb for consistency with other examples
         gl::Enable(gl::FRAMEBUFFER_SRGB);
         gl::ClearColor(0.02, 0.02, 0.02, 1.0);
-    }
+
+        uniform
+    };
 
     let mut text: String = include_str!("text/lipsum.txt").into();
     let mut font_size: f32 = 18.0;
@@ -134,10 +155,6 @@ fn main() -> Res<()> {
     let mut running = true;
     let mut vertex_count = 0;
     let mut vertex_max = vertex_count;
-    let mut dimensions = window
-        .get_inner_size()
-        .ok_or("get_inner_size = None")?
-        .to_physical(window.get_hidpi_factor());
 
     while running {
         loop_helper.loop_start();
@@ -154,6 +171,15 @@ fn main() -> Res<()> {
                             dimensions = ls.to_physical(dpi);
                             unsafe {
                                 gl::Viewport(0, 0, dimensions.width as _, dimensions.height as _);
+                                let transform = ortho(
+                                    0.0,
+                                    dimensions.width as _,
+                                    dimensions.height as _,
+                                    0.0,
+                                    1.0,
+                                    -1.0,
+                                );
+                                gl::UniformMatrix4fv(transform_uniform, 1, 0, transform.as_ptr());
                             }
                         }
                     }
@@ -431,14 +457,12 @@ fn to_vertex(
         gl_rect.min.x = gl_bounds.min.x;
         tex_coords.min.x = tex_coords.max.x - tex_coords.width() * gl_rect.width() / old_width;
     }
-    // note: y access is flipped gl compared with screen,
-    // texture is not flipped (ie is a headache)
-    if gl_rect.max.y < gl_bounds.max.y {
+    if gl_rect.max.y > gl_bounds.max.y {
         let old_height = gl_rect.height();
         gl_rect.max.y = gl_bounds.max.y;
         tex_coords.max.y = tex_coords.min.y + tex_coords.height() * gl_rect.height() / old_height;
     }
-    if gl_rect.min.y > gl_bounds.min.y {
+    if gl_rect.min.y < gl_bounds.min.y {
         let old_height = gl_rect.height();
         gl_rect.min.y = gl_bounds.min.y;
         tex_coords.min.y = tex_coords.max.y - tex_coords.height() * gl_rect.height() / old_height;
@@ -458,6 +482,19 @@ fn to_vertex(
         color[1],
         color[2],
         color[3],
+    ]
+}
+
+#[rustfmt::skip]
+fn ortho(left: f32, right: f32, bottom: f32, top: f32, near: f32, far: f32) -> [f32; 16] {
+    let tx = -(right + left) / (right - left);
+    let ty = -(top + bottom) / (top - bottom);
+    let tz = -(far + near) / (far - near);
+    [
+        2.0 / (right - left), 0.0, 0.0, 0.0,
+        0.0, 2.0 / (top - bottom), 0.0, 0.0,
+        0.0, 0.0, -2.0 / (far - near), 0.0,
+        tx, ty, tz, 1.0,
     ]
 }
 

--- a/glyph-brush/examples/opengl.rs
+++ b/glyph-brush/examples/opengl.rs
@@ -241,7 +241,6 @@ fn main() -> Res<()> {
         let mut brush_action;
         loop {
             brush_action = glyph_brush.process_queued(
-                (width as _, height as _),
                 |rect, tex_data| unsafe {
                     // Update part of gpu texture with new glyph alpha values
                     gl::BindTexture(gl::TEXTURE_2D, texture.name);
@@ -410,31 +409,15 @@ fn to_vertex(
         mut tex_coords,
         pixel_coords,
         bounds,
-        screen_dimensions: (screen_w, screen_h),
         color,
         z,
     }: glyph_brush::GlyphVertex,
 ) -> Vertex {
-    let gl_bounds = Rect {
-        min: point(
-            2.0 * (bounds.min.x / screen_w - 0.5),
-            2.0 * (0.5 - bounds.min.y / screen_h),
-        ),
-        max: point(
-            2.0 * (bounds.max.x / screen_w - 0.5),
-            2.0 * (0.5 - bounds.max.y / screen_h),
-        ),
-    };
+    let gl_bounds = bounds;
 
     let mut gl_rect = Rect {
-        min: point(
-            2.0 * (pixel_coords.min.x as f32 / screen_w - 0.5),
-            2.0 * (0.5 - pixel_coords.min.y as f32 / screen_h),
-        ),
-        max: point(
-            2.0 * (pixel_coords.max.x as f32 / screen_w - 0.5),
-            2.0 * (0.5 - pixel_coords.max.y as f32 / screen_h),
-        ),
+        min: point(pixel_coords.min.x as f32, pixel_coords.min.y as f32),
+        max: point(pixel_coords.max.x as f32, pixel_coords.max.y as f32),
     };
 
     // handle overlapping bounds, modify uv_rect to preserve texture aspect

--- a/glyph-brush/examples/shader/vert.glsl
+++ b/glyph-brush/examples/shader/vert.glsl
@@ -1,5 +1,7 @@
 #version 150
 
+uniform mat4 transform;
+
 in vec3 left_top;
 in vec2 right_bottom;
 in vec2 tex_left_top;
@@ -37,5 +39,5 @@ void main() {
     }
 
     f_color = color;
-    gl_Position = vec4(pos, left_top.z, 1.0);
+    gl_Position = transform * vec4(pos, left_top.z, 1.0);
 }

--- a/glyph-brush/examples/shader/vert.glsl
+++ b/glyph-brush/examples/shader/vert.glsl
@@ -1,5 +1,12 @@
 #version 150
 
+const mat4 INVERT_Y_AXIS = mat4(
+    vec4(1.0, 0.0, 0.0, 0.0),
+    vec4(0.0, -1.0, 0.0, 0.0),
+    vec4(0.0, 0.0, 1.0, 0.0),
+    vec4(0.0, 0.0, 0.0, 1.0)
+);
+
 uniform mat4 transform;
 
 in vec3 left_top;
@@ -39,5 +46,5 @@ void main() {
     }
 
     f_color = color;
-    gl_Position = transform * vec4(pos, left_top.z, 1.0);
+    gl_Position = INVERT_Y_AXIS * transform * vec4(pos, left_top.z, 1.0);
 }

--- a/glyph-brush/src/lib.rs
+++ b/glyph-brush/src/lib.rs
@@ -12,11 +12,9 @@
 //! });
 //! glyph_brush.queue(some_other_section);
 //!
-//! # let screen_dimensions = (1024, 768);
 //! # let update_texture = |_, _| {};
 //! # let into_vertex = |_| ();
 //! match glyph_brush.process_queued(
-//!     screen_dimensions,
 //!     |rect, tex_data| update_texture(rect, tex_data),
 //!     |vertex_data| into_vertex(vertex_data),
 //! ) {

--- a/glyph-brush/src/section.rs
+++ b/glyph-brush/src/section.rs
@@ -70,8 +70,6 @@ impl<'a, 'b> From<&'b VariedSection<'a>> for Cow<'b, VariedSection<'a>> {
 
 impl Hash for VariedSection<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        use ordered_float::OrderedFloat;
-
         let VariedSection {
             screen_position: (screen_x, screen_y),
             bounds: (bound_w, bound_h),


### PR DESCRIPTION
Fixes #63.

This removes the screen size dependency as I described in #63. These are just the basic changes to get the `gfx_glyph` paragraph example to work. All the other examples probably need to be adapted.

I personally think the code becomes much simpler. Let me know what you think and how to proceed.