### PR TITLE
Make `depth_target` optional in `gfx_glyph`

### DIFF
--- a/gfx-glyph/examples/depth.rs
+++ b/gfx-glyph/examples/depth.rs
@@ -117,7 +117,10 @@ fn main() -> Result<(), Box<dyn Error>> {
             ..Section::default()
         });
 
-        glyph_brush.draw_queued(&mut encoder, &main_color, Some(&main_depth))?;
+        glyph_brush
+            .use_queue()
+            .depth_target(&main_depth)
+            .draw(&mut encoder, &main_color)?;
 
         encoder.flush(&mut device);
         window_ctx.swap_buffers()?;

--- a/gfx-glyph/examples/depth.rs
+++ b/gfx-glyph/examples/depth.rs
@@ -117,7 +117,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             ..Section::default()
         });
 
-        glyph_brush.draw_queued(&mut encoder, &main_color, &main_depth)?;
+        glyph_brush.draw_queued(&mut encoder, &main_color, Some(&main_depth))?;
 
         encoder.flush(&mut device);
         window_ctx.swap_buffers()?;

--- a/gfx-glyph/examples/paragraph.rs
+++ b/gfx-glyph/examples/paragraph.rs
@@ -251,7 +251,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             transform.into(),
             &mut encoder,
             &main_color,
-            &main_depth,
+            Some(&main_depth),
         )?;
 
         encoder.flush(&mut device);

--- a/gfx-glyph/examples/paragraph.rs
+++ b/gfx-glyph/examples/paragraph.rs
@@ -224,9 +224,6 @@ fn main() -> Result<(), Box<dyn Error>> {
             ..Section::default()
         });
 
-        // Note: Can be drawn simply with the below, when transforms are not needed:
-        // `glyph_brush.draw_queued(&mut encoder, &main_color, &main_depth)?;`
-
         // Rotation
         let offset = Matrix4::from_translation(Vector3::new(-width / 2.0, -height / 2.0, 0.0));
         let rotation =
@@ -247,12 +244,11 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Note: Drawing in the case the text is unchanged from the previous frame (a common case)
         // is essentially free as the vertices are reused & gpu cache updating interaction
         // can be skipped.
-        glyph_brush.draw_queued_with_transform(
-            transform.into(),
-            &mut encoder,
-            &main_color,
-            Some(&main_depth),
-        )?;
+        glyph_brush
+            .use_queue()
+            .transform(transform)
+            .depth_target(&main_depth)
+            .draw(&mut encoder, &main_color)?;
 
         encoder.flush(&mut device);
         window_ctx.swap_buffers()?;

--- a/gfx-glyph/examples/performance.rs
+++ b/gfx-glyph/examples/performance.rs
@@ -140,7 +140,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Note: Drawing in the case the text is unchanged from the previous frame (a common case)
         // is essentially free as the vertices are reused &  gpu cache updating interaction
         // can be skipped.
-        glyph_brush.draw_queued(&mut encoder, &main_color, Some(&main_depth))?;
+        glyph_brush.use_queue().draw(&mut encoder, &main_color)?;
 
         encoder.flush(&mut device);
         window_ctx.swap_buffers()?;

--- a/gfx-glyph/examples/performance.rs
+++ b/gfx-glyph/examples/performance.rs
@@ -140,7 +140,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         // Note: Drawing in the case the text is unchanged from the previous frame (a common case)
         // is essentially free as the vertices are reused &  gpu cache updating interaction
         // can be skipped.
-        glyph_brush.draw_queued(&mut encoder, &main_color, &main_depth)?;
+        glyph_brush.draw_queued(&mut encoder, &main_color, Some(&main_depth))?;
 
         encoder.flush(&mut device);
         window_ctx.swap_buffers()?;

--- a/gfx-glyph/examples/pre_positioned.rs
+++ b/gfx-glyph/examples/pre_positioned.rs
@@ -103,7 +103,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             0.0,
         );
 
-        glyph_brush.draw_queued(&mut encoder, &main_color, &main_depth)?;
+        glyph_brush.draw_queued(&mut encoder, &main_color, Some(&main_depth))?;
 
         encoder.flush(&mut device);
         window_ctx.swap_buffers()?;

--- a/gfx-glyph/examples/pre_positioned.rs
+++ b/gfx-glyph/examples/pre_positioned.rs
@@ -103,7 +103,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             0.0,
         );
 
-        glyph_brush.draw_queued(&mut encoder, &main_color, Some(&main_depth))?;
+        glyph_brush.use_queue().draw(&mut encoder, &main_color)?;
 
         encoder.flush(&mut device);
         window_ctx.swap_buffers()?;

--- a/gfx-glyph/examples/varied.rs
+++ b/gfx-glyph/examples/varied.rs
@@ -164,7 +164,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             ..VariedSection::default()
         });
 
-        glyph_brush.draw_queued(&mut encoder, &main_color, Some(&main_depth))?;
+        glyph_brush.use_queue().draw(&mut encoder, &main_color)?;
 
         encoder.flush(&mut device);
         window_ctx.swap_buffers()?;

--- a/gfx-glyph/examples/varied.rs
+++ b/gfx-glyph/examples/varied.rs
@@ -164,7 +164,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             ..VariedSection::default()
         });
 
-        glyph_brush.draw_queued(&mut encoder, &main_color, &main_depth)?;
+        glyph_brush.draw_queued(&mut encoder, &main_color, Some(&main_depth))?;
 
         encoder.flush(&mut device);
         window_ctx.swap_buffers()?;

--- a/gfx-glyph/src/draw_builder.rs
+++ b/gfx-glyph/src/draw_builder.rs
@@ -1,0 +1,83 @@
+use crate::{
+    default_transform, GlyphBrush, RawAndFormat, RawDepthStencilView, RawRenderTargetView,
+};
+use std::{hash::BuildHasher, marker::PhantomData};
+
+#[must_use]
+pub struct DrawBuilder<'a, 'font, R: gfx::Resources, F: gfx::Factory<R>, H, DV> {
+    pub(crate) brush: &'a mut GlyphBrush<'font, R, F, H>,
+    pub(crate) transform: Option<[[f32; 4]; 4]>,
+    pub(crate) depth_target: Option<&'a DV>,
+}
+
+impl<'a, 'font, R: gfx::Resources, F: gfx::Factory<R>, H: BuildHasher, DV>
+    DrawBuilder<'a, 'font, R, F, H, DV>
+{
+    #[inline]
+    pub fn transform<M: Into<[[f32; 4]; 4]>>(mut self, transform: M) -> Self {
+        self.transform = Some(transform.into());
+        self
+    }
+
+    #[inline]
+    pub fn depth_target<D>(self, depth: &'a D) -> DrawBuilder<'a, 'font, R, F, H, D> {
+        let Self {
+            brush, transform, ..
+        } = self;
+        DrawBuilder {
+            depth_target: Some(depth),
+            brush,
+            transform,
+        }
+    }
+}
+
+impl<
+        'a,
+        R: gfx::Resources,
+        F: gfx::Factory<R>,
+        H: BuildHasher,
+        DV: RawAndFormat<Raw = RawDepthStencilView<R>>,
+    > DrawBuilder<'a, '_, R, F, H, DV>
+{
+    #[inline]
+    pub fn draw<C, CV>(self, encoder: &mut gfx::Encoder<R, C>, target: &CV) -> Result<(), String>
+    where
+        C: gfx::CommandBuffer<R>,
+        CV: RawAndFormat<Raw = RawRenderTargetView<R>>,
+    {
+        let Self {
+            brush,
+            transform,
+            depth_target,
+        } = self;
+        let transform = transform.unwrap_or_else(|| default_transform(target));
+        brush.draw(transform, encoder, target, depth_target)
+    }
+}
+
+struct NoDepth<R: gfx::Resources>(PhantomData<R>);
+impl<R: gfx::Resources> RawAndFormat for NoDepth<R> {
+    type Raw = RawDepthStencilView<R>;
+    fn as_raw(&self) -> &Self::Raw {
+        unreachable!()
+    }
+    fn format(&self) -> gfx::format::Format {
+        unreachable!()
+    }
+}
+
+impl<'a, R: gfx::Resources, F: gfx::Factory<R>, H: BuildHasher> DrawBuilder<'a, '_, R, F, H, ()> {
+    #[inline]
+    pub fn draw<C, CV>(self, encoder: &mut gfx::Encoder<R, C>, target: &CV) -> Result<(), String>
+    where
+        C: gfx::CommandBuffer<R>,
+        CV: RawAndFormat<Raw = RawRenderTargetView<R>>,
+    {
+        let Self {
+            brush, transform, ..
+        } = self;
+        let transform = transform.unwrap_or_else(|| default_transform(target));
+        brush.draw::<C, CV, NoDepth<R>>(transform, encoder, target, None)
+    }
+}


### PR DESCRIPTION
Fixes #65.

I basically let the compiler drive me here. Not sure if everything is correct, but I tried some examples (`depth` included) and they seem to work.

Also, when I use `None` I have to provide all the generic types:

```rust
self.glyphs
    .draw_queued_with_transform::<gl::CommandBuffer, RenderTargetView, (&DepthView, gfx::format::Format)>(
        transformation.into(),
        encoder,
        &typed_target,
        None,
    )
```

Not sure if this can be avoided, I am quite new to Rust. Let me know what you think!