### PR TITLE
Remove hashbrown as this is in std 1.36

### DIFF
--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Replace `hashbrown` with `rustc-hash` + `std::collections` these are the same in 1.36.
+
 # 0.5.3
 * Fix `queue_pre_positioned` cache check for position & scale changes.
 

--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -14,7 +14,7 @@ glyph_brush_layout = { version = "0.1.5", path = "../glyph-brush-layout" }
 log = "0.4.4"
 ordered-float = "1"
 full_rusttype = { version = "0.7.7", features = ["gpu_cache"], package = "rusttype" }
-hashbrown = "0.5"
+rustc-hash = "1"
 twox-hash = "1"
 
 [dev-dependencies]

--- a/glyph-brush/examples/opengl.rs
+++ b/glyph-brush/examples/opengl.rs
@@ -17,7 +17,7 @@ use std::{
     mem, ptr, str,
 };
 
-type Res<T> = Result<T, Box<std::error::Error>>;
+type Res<T> = Result<T, Box<dyn std::error::Error>>;
 /// `[left_top * 3, right_bottom * 2, tex_left_top * 2, tex_right_bottom * 2, color * 4]`
 type Vertex = [GLfloat; 13];
 

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -5,6 +5,7 @@ pub use self::builder::*;
 use super::*;
 use full_rusttype::gpu_cache::{Cache, CachedBy};
 use log::error;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::{
     borrow::Cow,
     fmt,
@@ -39,7 +40,7 @@ pub struct GlyphBrush<'font, V: Clone + 'static, H = DefaultSectionHasher> {
 
     // cache of section-layout hash -> computed glyphs, this avoid repeated glyph computation
     // for identical layout/sections common to repeated frame rendering
-    calculate_glyph_cache: hashbrown::HashMap<SectionHash, Glyphed<'font, V>>,
+    calculate_glyph_cache: FxHashMap<SectionHash, Glyphed<'font, V>>,
 
     last_frame_seq_id_sections: Vec<SectionHashDetail>,
     frame_seq_id_sections: Vec<SectionHashDetail>,
@@ -49,7 +50,7 @@ pub struct GlyphBrush<'font, V: Clone + 'static, H = DefaultSectionHasher> {
     section_buffer: Vec<SectionHash>,
 
     // Set of section hashs to keep in the glyph cache this frame even if they haven't been drawn
-    keep_in_cache: hashbrown::HashSet<SectionHash>,
+    keep_in_cache: FxHashSet<SectionHash>,
 
     // config
     cache_glyph_positioning: bool,


### PR DESCRIPTION
Replace with direct `rustc-hash` usage.