### PR TITLE
GlyphBrush rebuilding

### DIFF
--- a/gfx-glyph/src/builder.rs
+++ b/gfx-glyph/src/builder.rs
@@ -143,7 +143,8 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
         R: gfx::Resources,
         F: gfx::Factory<R>,
     {
-        let (cache_width, cache_height) = self.inner.initial_cache_size;
+        let inner = self.inner.build();
+        let (cache_width, cache_height) = inner.texture_dimensions();
         let font_cache_tex = create_texture(&mut factory, cache_width, cache_height).unwrap();
         let program = factory
             .link_program(
@@ -155,7 +156,7 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
         GlyphBrush {
             font_cache_tex,
             texture_filter_method: self.texture_filter_method,
-            glyph_brush: self.inner.build(),
+            glyph_brush: inner,
 
             factory,
             program,

--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+* `GlyphBrushBuilder` removed `initial_cache_size`, `gpu_cache_scale_tolerance`, `gpu_cache_position_tolerance`, `gpu_cache_align_4x4` public fields replaced by `gpu_cache_builder` field. This change allows the following changes.
+* Add `GlyphBrush::to_builder` method to construct `GlyphBrushBuilder`s from `GlyphBrush`.
+* Add `GlyphBrushBuilder::replace_fonts`, `GlyphBrushBuilder::rebuild` methods. Along with `to_builder` these may be used to rebuild a `GlyphBrush` with different fonts more conveniently.
 * Replace `hashbrown` with `rustc-hash` + `std::collections` these are the same in 1.36.
 
 # 0.5.3

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -247,7 +247,8 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
         }
     }
 
-    /// Rebuilds an existing `GlyphBrush` with this builder's properties.
+    /// Rebuilds an existing `GlyphBrush` with this builder's properties. This will clear all
+    /// caches and queues.
     ///
     /// # Example
     /// ```


### PR DESCRIPTION
* Add `GlyphBrush::to_builder` method to construct `GlyphBrushBuilder`s from `GlyphBrush`.
* Add `GlyphBrushBuilder::replace_fonts`, `GlyphBrushBuilder::rebuild` methods. Along with `to_builder` these may be used to rebuild a `GlyphBrush` with different fonts more conveniently.
* `GlyphBrushBuilder` removed `initial_cache_size`, `gpu_cache_scale_tolerance`, `gpu_cache_position_tolerance`, `gpu_cache_align_4x4` public fields replaced by `gpu_cache_builder` field.

This gives a more convenient way to remove fonts.
```rust
self.glyph_brush
    .to_builder()
    .replace_fonts(|mut fonts| {
        fonts.remove(0);
        fonts
    })
    .rebuild(&mut self.glyph_brush);
```
Rebuilding means caches are all cleared, it's essentially the same as replacing with a new GlyphBrush.

Resolves #72 maybe