### PR TITLE
Implement FontMap for GlyphBrush and GlyphCalculator

### DIFF
--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -509,6 +509,13 @@ impl<'font, V, H: BuildHasher + Clone> GlyphBrush<'font, V, H> {
     }
 }
 
+impl<'font, V, H> FontMap<'font> for GlyphBrush<'font, V, H> {
+    #[inline]
+    fn font(&self, id: FontId) -> &Font<'font> {
+        self.fonts.font(id)
+    }
+}
+
 #[derive(Debug, Default, PartialEq)]
 struct LastDrawInfo {
     text_state: u64,

--- a/glyph-brush/src/glyph_calculator.rs
+++ b/glyph-brush/src/glyph_calculator.rs
@@ -223,6 +223,13 @@ pub struct GlyphCalculator<'font, H = DefaultSectionHasher> {
     section_hasher: H,
 }
 
+impl<'font, H> FontMap<'font> for GlyphCalculator<'font, H> {
+    #[inline]
+    fn font(&self, id: FontId) -> &Font<'font> {
+        self.fonts.font(id)
+    }
+}
+
 impl<H> fmt::Debug for GlyphCalculator<'_, H> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "GlyphCalculator")


### PR DESCRIPTION
Maybe there's a reason you didn't implement this? Otherwise, I assume it's an oversight. This allows access to font methods (e.g. `Font::v_metrics` and `Font::glyph`) without keeping a separate copy of the `Font` (although I understand this is cheap enough to do).