### PR TITLE
Fix word layout bounds floating point error

### DIFF
--- a/glyph-brush-layout/CHANGELOG.md
+++ b/glyph-brush-layout/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+* Fix consistency of section bounds by removing usage of glyph pixel bounds during word layout, instead always relying
+  on advance width.
+* Fix possible floating point errors when using section bounds that exactly bound the section.
+
 # 0.1.8
 * Update rusttype -> `0.8`. _Compatible with rusttype `0.6.5` & `0.7.9`._
 

--- a/glyph-brush-layout/Cargo.toml
+++ b/glyph-brush-layout/Cargo.toml
@@ -12,8 +12,8 @@ readme="README.md"
 [dependencies]
 full_rusttype = { version = "0.8", package = "rusttype" }
 xi-unicode = "0.2"
+approx = "0.3.2"
 
 [dev-dependencies]
-approx = "0.3.1"
 once_cell = "1"
 ordered-float = "1"

--- a/glyph-brush-layout/src/lines.rs
+++ b/glyph-brush-layout/src/lines.rs
@@ -102,8 +102,14 @@ impl<'font, L: LineBreaker, F: FontMap<'font>> Iterator for Lines<'_, '_, 'font,
         let mut progressed = false;
 
         while let Some(word) = self.words.peek() {
+            let word_in_bounds = {
+                let word_x = caret.x + word.layout_width_no_trail;
+                // Reduce float errors by using relative "<= width bound" check
+                word_x < self.width_bound || approx::relative_eq!(word_x, self.width_bound)
+            };
+
             // only if `progressed` means the first word is allowed to overlap the bounds
-            if progressed && caret.x + word.layout_width_no_trail > self.width_bound {
+            if !word_in_bounds && progressed {
                 break;
             }
 

--- a/glyph-brush/src/glyph_calculator.rs
+++ b/glyph-brush/src/glyph_calculator.rs
@@ -782,4 +782,35 @@ mod test {
             assert_relative_eq!(glyph.position().y, bounded_glyph.position().y);
         }
     }
+
+    /// Similar to `glyph_bound_section_bound_consistency` but produces a floating point
+    /// error between the calculated glyph_bounds bounds & those used during layout.
+    #[test]
+    fn glyph_bound_section_bound_consistency_floating_point() {
+        let calc = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build();
+        let mut calc = calc.cache_scope();
+
+        let section = Section {
+            text: "Eins Zwei Drei Vier Funf",
+            ..<_>::default()
+        };
+
+        let glyph_bounds = calc.glyph_bounds(&section).expect("None bounds");
+
+        // identical section with bounds that should be wide enough
+        let bounded_section = Section {
+            bounds: (glyph_bounds.width(), glyph_bounds.height()),
+            ..section
+        };
+
+        let glyphs: Vec<_> = calc.glyphs(&section).cloned().collect();
+        let bounded_glyphs: Vec<_> = calc.glyphs(&bounded_section).collect();
+
+        assert_eq!(glyphs.len(), bounded_glyphs.len());
+
+        for (glyph, bounded_glyph) in glyphs.iter().zip(bounded_glyphs.into_iter()) {
+            assert_relative_eq!(glyph.position().x, bounded_glyph.position().x);
+            assert_relative_eq!(glyph.position().y, bounded_glyph.position().y);
+        }
+    }
 }


### PR DESCRIPTION
There's a possibility when using exact section bounds that a floating point error will cause the layout to regard the word as out of bounds incorrectly (reproduced in `glyph_bound_section_bound_consistency_floating_point`).

This pr fixes that by using the **approx** crate to make a relative `word_w <= w_bound` check. This adds **approx** as an additional dependency, but it's already in the tree anyway thanks to rusttype.

Relies on #90 to go in first.