### PR TITLE
Implement an indexed glyph brush

### DIFF
--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -550,26 +550,6 @@ pub enum BrushAction<V> {
     ReDraw,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum BrushError {
-    /// Texture is too small to cache queued glyphs
-    ///
-    /// A larger suggested size is included.
-    TextureTooSmall { suggested: (u32, u32) },
-}
-impl fmt::Display for BrushError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", std::error::Error::description(self))
-    }
-}
-impl std::error::Error for BrushError {
-    fn description(&self) -> &str {
-        match self {
-            BrushError::TextureTooSmall { .. } => "Texture is too small to cache queued glyphs",
-        }
-    }
-}
-
 #[derive(Debug, Clone, Copy)]
 struct SectionHashDetail {
     /// hash of text (- color - alpha - geo - z)
@@ -707,7 +687,6 @@ impl<'font, V> Glyphed<'font, V> {
             }));
     }
 }
-
 
 #[cfg(test)]
 mod hash_diff_test {

--- a/glyph-brush/src/glyph_brush_indexed.rs
+++ b/glyph-brush/src/glyph_brush_indexed.rs
@@ -1,0 +1,393 @@
+mod builder;
+
+pub use self::builder::*;
+
+use super::*;
+use full_rusttype::gpu_cache::{Cache, CachedBy};
+use log::error;
+use std::{borrow::Cow, fmt, i32};
+
+/// Similar to [GlyphBrush] but lets the user control when to cache and un-cache a section.
+///
+/// Each section is [push_section](GlyphBrushIndexed::push_section)ed and [pop_section](GlyphBrushIndexed::pop_section), alternatively [remove_section](GlyphBrushIndexed::remove_section) is also available to remove
+/// sections from the middle of the section list.
+pub struct GlyphBrushIndexed<'font, V> {
+    fonts: Vec<Font<'font>>,
+    texture_cache: Cache<'font>,
+
+    glyph_store: Vec<Glyphed<'font, V>>,
+
+    glyphs_custom_layout: Option<Glyphed<'font, V>>,
+}
+
+impl<V> fmt::Debug for GlyphBrushIndexed<'_, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "GlyphBrushIndexed")
+    }
+}
+
+impl<'font, V> GlyphCruncher<'font> for GlyphBrushIndexed<'font, V>
+where
+    V: Clone + 'static,
+{
+    fn pixel_bounds_custom_layout<'a, S, L>(&mut self, section: S, layout: &L) -> Option<Rect<i32>>
+    where
+        L: GlyphPositioner,
+        S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        let section = section.into();
+
+        match section {
+            Cow::Borrowed(section) => {
+                let geometry = SectionGeometry::from(section);
+
+                Glyphed::<'font, V>::new(GlyphedSection {
+                    bounds: layout.bounds_rect(&geometry),
+                    glyphs: layout.calculate_glyphs(&self.fonts, &geometry, &section.text),
+                    z: section.z,
+                })
+                .positioned
+                .pixel_bounds()
+            }
+            Cow::Owned(section) => {
+                let geometry = SectionGeometry::from(&section);
+
+                Glyphed::<'font, V>::new(GlyphedSection {
+                    bounds: layout.bounds_rect(&geometry),
+                    glyphs: layout.calculate_glyphs(&self.fonts, &geometry, &section.text),
+                    z: section.z,
+                })
+                .positioned
+                .pixel_bounds()
+            }
+        }
+    }
+
+    fn glyphs_custom_layout<'a, 'b, S, L>(
+        &'b mut self,
+        section: S,
+        layout: &L,
+    ) -> PositionedGlyphIter<'b, 'font>
+    where
+        L: GlyphPositioner,
+        S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        let section = section.into();
+
+        match section {
+            Cow::Borrowed(section) => {
+                let geometry = SectionGeometry::from(section);
+
+                self.glyphs_custom_layout = Some(Glyphed::<'font, V>::new(GlyphedSection {
+                    bounds: layout.bounds_rect(&geometry),
+                    glyphs: layout.calculate_glyphs(&self.fonts, &geometry, &section.text),
+                    z: section.z,
+                }));
+            }
+            Cow::Owned(section) => {
+                let geometry = SectionGeometry::from(&section);
+
+                self.glyphs_custom_layout = Some(Glyphed::<'font, V>::new(GlyphedSection {
+                    bounds: layout.bounds_rect(&geometry),
+                    glyphs: layout.calculate_glyphs(&self.fonts, &geometry, &section.text),
+                    z: section.z,
+                }));
+            }
+        }
+
+        self.glyphs_custom_layout
+            .as_ref()
+            .unwrap()
+            .positioned
+            .glyphs()
+    }
+
+    fn fonts(&self) -> &[Font<'font>] {
+        &self.fonts
+    }
+}
+
+impl<'font, V> GlyphBrushIndexed<'font, V>
+where
+    V: Clone + 'static,
+{
+    /// Add a section to this brush with a custom layout.
+    pub fn push_section_custom_layout<'a, S, G>(&mut self, section: S, custom_layout: &G)
+    where
+        G: GlyphPositioner,
+        S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        let section = section.into();
+        if cfg!(debug_assertions) {
+            for text in &section.text {
+                assert!(self.fonts.len() > text.font_id.0, "Invalid font id");
+            }
+        }
+        self.cache_glyphs(&section, custom_layout);
+    }
+
+    /// Add a section to this brush.
+    ///
+    /// ```no_run
+    /// # use glyph_brush::*;
+    /// # let dejavu: &[u8] = include_bytes!("../../fonts/DejaVuSans.ttf");
+    /// # let mut glyph_brush: GlyphBrushIndexed<'_, ()> = GlyphBrushIndexedBuilder::using_font_bytes(dejavu).build();
+    /// glyph_brush.push_section(Section {
+    ///     text: "Hello glyph_brush",
+    ///     ..Section::default()
+    /// });
+    /// ```
+    pub fn push_section<'a, S>(&mut self, section: S)
+    where
+        S: Into<Cow<'a, VariedSection<'a>>>,
+    {
+        let section = section.into();
+        let layout = section.layout;
+        self.push_section_custom_layout(section, &layout)
+    }
+
+    /// Adds a section to the glyph list.
+    fn cache_glyphs<L>(&mut self, section: &VariedSection<'_>, layout: &L)
+    where
+        L: GlyphPositioner,
+    {
+        let geometry = SectionGeometry::from(section);
+
+        self.glyph_store.push(Glyphed::new(GlyphedSection {
+            bounds: layout.bounds_rect(&geometry),
+            glyphs: layout.calculate_glyphs(&self.fonts, &geometry, &section.text),
+            z: section.z,
+        }));
+    }
+
+    /// Process all sections, returning the texel changes as well as any indices which need to
+    /// re-evaluate their their texture coordinates.
+    pub fn process_sections<F1, F2>(
+        &mut self,
+        update_texture: F1,
+        to_vertex: F2,
+    ) -> Result<BrushActionIndexed<V>, BrushError>
+    where
+        F1: FnMut(Rect<u32>, &[u8]),
+        F2: Fn(GlyphVertex) -> V + Copy,
+    {
+        for glyphs in &self.glyph_store {
+            for (glyph, _, font) in &glyphs.positioned.glyphs {
+                self.texture_cache.queue_glyph(font.0, glyph.clone());
+            }
+        }
+
+        match self.texture_cache.cache_queued(update_texture) {
+            Ok(CachedBy::Adding) => {}
+            Ok(CachedBy::Reordering) => {
+                for glyphed in &mut self.glyph_store {
+                    glyphed.invalidate_texture_positions();
+                }
+            }
+            Err(_) => {
+                let (width, height) = self.texture_cache.dimensions();
+                return Err(BrushError::TextureTooSmall {
+                    suggested: (width * 2, height * 2),
+                });
+            }
+        }
+
+        Ok(BrushActionIndexed::Draw({
+            let mut verts = Vec::new();
+
+            for (idx, glyphed) in self.glyph_store.iter_mut().enumerate() {
+                if glyphed.needs_recalculation() {
+                    glyphed.ensure_vertices(&self.texture_cache, to_vertex);
+                    verts.push((idx, glyphed.vertices.to_vec()));
+                }
+            }
+
+            verts
+        }))
+    }
+
+    /// Remove a section given by some index. Note that this shifts the indices of all subsequent
+    /// sections down by one.
+    pub fn remove_section(&mut self, index: usize) {
+        self.glyph_store.remove(index);
+    }
+
+    /// Pop the last pushed section.
+    pub fn pop_section(&mut self) {
+        self.glyph_store.pop();
+    }
+
+    /// Rebuilds the logical texture cache with new dimensions. Should be avoided if possible.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use glyph_brush::*;
+    /// # let dejavu: &[u8] = include_bytes!("../../fonts/DejaVuSans.ttf");
+    /// # let mut glyph_brush: GlyphBrushIndexed<'_, ()> = GlyphBrushIndexedBuilder::using_font_bytes(dejavu).build();
+    /// glyph_brush.resize_texture(512, 512);
+    /// ```
+    pub fn resize_texture(&mut self, new_width: u32, new_height: u32) {
+        self.texture_cache
+            .to_builder()
+            .dimensions(new_width, new_height)
+            .rebuild(&mut self.texture_cache);
+
+        // invalidate any previous cache position data
+        for glyphed in &mut self.glyph_store {
+            glyphed.invalidate_texture_positions();
+        }
+    }
+
+    /// Returns the logical texture cache pixel dimensions `(width, height)`.
+    pub fn texture_dimensions(&self) -> (u32, u32) {
+        self.texture_cache.dimensions()
+    }
+
+    /// Adds an additional font to the one(s) initially added on build.
+    ///
+    /// Returns a new [`FontId`](struct.FontId.html) to reference this font.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use glyph_brush::{GlyphBrushIndexed, GlyphBrushIndexedBuilder, Section};
+    /// # type Vertex = ();
+    ///
+    /// // dejavu is built as default `FontId(0)`
+    /// let dejavu: &[u8] = include_bytes!("../../fonts/DejaVuSans.ttf");
+    /// let mut glyph_brush: GlyphBrushIndexed<'_, Vertex> =
+    ///     GlyphBrushIndexedBuilder::using_font_bytes(dejavu).build();
+    ///
+    /// // some time later, add another font referenced by a new `FontId`
+    /// let open_sans_italic: &[u8] = include_bytes!("../../fonts/OpenSans-Italic.ttf");
+    /// let open_sans_italic_id = glyph_brush.add_font_bytes(open_sans_italic);
+    /// ```
+    pub fn add_font_bytes<'a: 'font, B: Into<SharedBytes<'a>>>(&mut self, font_data: B) -> FontId {
+        self.add_font(Font::from_bytes(font_data.into()).unwrap())
+    }
+
+    /// Adds an additional font to the one(s) initially added on build.
+    ///
+    /// Returns a new [`FontId`](struct.FontId.html) to reference this font.
+    pub fn add_font<'a: 'font>(&mut self, font_data: Font<'a>) -> FontId {
+        self.fonts.push(font_data);
+        FontId(self.fonts.len() - 1)
+    }
+}
+
+impl<'font, V> GlyphBrushIndexed<'font, V> {
+    /// Return a [`GlyphBrushIndexedBuilder`](struct.GlyphBrushIndexedBuilder.html) prefilled with the
+    /// properties of this `GlyphBrushIndexed`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use glyph_brush::{*, rusttype::*};
+    /// # type Vertex = ();
+    /// # let sans = Font::from_bytes(&include_bytes!("../../fonts/DejaVuSans.ttf")[..]).unwrap();
+    /// let glyph_brush: GlyphBrushIndexed<'_, Vertex> = GlyphBrushIndexedBuilder::using_font(sans)
+    ///     .initial_cache_size((128, 128))
+    ///     .build();
+    ///
+    /// let new_brush: GlyphBrushIndexed<'_, Vertex> = glyph_brush.to_builder().build();
+    /// assert_eq!(new_brush.texture_dimensions(), (128, 128));
+    /// ```
+    pub fn to_builder(&self) -> GlyphBrushIndexedBuilder<'font> {
+        let mut builder = GlyphBrushIndexedBuilder::using_fonts(self.fonts.clone());
+        builder.gpu_cache_builder = self.texture_cache.to_builder();
+        builder
+    }
+}
+
+/// Data used to generate vertex information for a single glyph
+#[derive(Debug)]
+pub struct GlyphVertex {
+    pub tex_coords: Rect<f32>,
+    pub pixel_coords: Rect<i32>,
+    pub bounds: Rect<f32>,
+    pub color: Color,
+    pub z: f32,
+}
+
+/// Actions that should be taken after processing push data
+#[derive(Debug)]
+pub enum BrushActionIndexed<V> {
+    /// Draw new/changed vertex data.
+    Draw(Vec<(usize, Vec<V>)>),
+}
+
+/// Container for positioned glyphs which can generate and cache vertices
+struct Glyphed<'font, V> {
+    positioned: GlyphedSection<'font>,
+    vertices: Vec<V>,
+}
+
+impl<V> PartialEq for Glyphed<'_, V> {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.positioned == other.positioned
+    }
+}
+
+impl<'font, V> Glyphed<'font, V> {
+    #[inline]
+    fn new(gs: GlyphedSection<'font>) -> Self {
+        Self {
+            positioned: gs,
+            vertices: Vec::new(),
+        }
+    }
+
+    /// Mark previous texture positions as no longer valid (vertices require re-generation)
+    fn invalidate_texture_positions(&mut self) {
+        self.vertices.clear();
+    }
+
+    /// Check if this glyph collection needs re-computation.
+    fn needs_recalculation(&self) -> bool {
+        self.vertices.is_empty()
+    }
+
+    /// Calculate vertices if not already done
+    fn ensure_vertices<F>(&mut self, texture_cache: &Cache<'font>, to_vertex: F)
+    where
+        F: Fn(GlyphVertex) -> V,
+    {
+        let GlyphedSection {
+            bounds,
+            z,
+            ref glyphs,
+        } = self.positioned;
+
+        self.vertices.reserve(glyphs.len());
+        self.vertices
+            .extend(glyphs.iter().filter_map(|(glyph, color, font_id)| {
+                match texture_cache.rect_for(font_id.0, glyph) {
+                    Err(err) => {
+                        error!("Cache miss?: {:?}, {:?}: {}", font_id, glyph, err);
+                        None
+                    }
+                    Ok(None) => None,
+                    Ok(Some((tex_coords, pixel_coords))) => {
+                        if pixel_coords.min.x as f32 > bounds.max.x
+                            || pixel_coords.min.y as f32 > bounds.max.y
+                            || bounds.min.x > pixel_coords.max.x as f32
+                            || bounds.min.y > pixel_coords.max.y as f32
+                        {
+                            // glyph is totally outside the bounds
+                            None
+                        } else {
+                            Some(to_vertex(GlyphVertex {
+                                tex_coords,
+                                pixel_coords,
+                                bounds,
+                                color: *color,
+                                z,
+                            }))
+                        }
+                    }
+                }
+            }));
+    }
+}

--- a/glyph-brush/src/glyph_brush_indexed/builder.rs
+++ b/glyph-brush/src/glyph_brush_indexed/builder.rs
@@ -1,0 +1,206 @@
+use crate::{Font, FontId, GlyphBrushIndexed, SharedBytes};
+use full_rusttype::gpu_cache::{Cache, CacheBuilder};
+
+/// Builder for a [`GlyphBrushIndexed`](struct.GlyphBrushIndexed.html).
+///
+/// # Example
+///
+/// ```
+/// use glyph_brush::{GlyphBrushIndexed, GlyphBrushIndexedBuilder};
+/// # type Vertex = ();
+///
+/// let dejavu: &[u8] = include_bytes!("../../../fonts/DejaVuSans.ttf");
+/// let mut glyph_brush: GlyphBrushIndexed<'_, Vertex> =
+///     GlyphBrushIndexedBuilder::using_font_bytes(dejavu).build();
+/// ```
+pub struct GlyphBrushIndexedBuilder<'a> {
+    pub font_data: Vec<Font<'a>>,
+    pub gpu_cache_builder: CacheBuilder,
+    _private_construction: (),
+}
+
+impl<'a> GlyphBrushIndexedBuilder<'a> {
+    /// Create a new builder with a single font's data that will be used to render glyphs.
+    /// Referenced with `FontId(0)`, which is default.
+    pub fn using_font_bytes<B: Into<SharedBytes<'a>>>(font_0_data: B) -> Self {
+        Self::using_font(Font::from_bytes(font_0_data).unwrap())
+    }
+
+    /// Create a new builder with multiple fonts' data.
+    pub fn using_fonts_bytes<B, V>(font_data: V) -> Self
+    where
+        B: Into<SharedBytes<'a>>,
+        V: IntoIterator<Item = B>,
+    {
+        Self::using_fonts(
+            font_data
+                .into_iter()
+                .map(|data| Font::from_bytes(data).unwrap())
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Create a new builder with a single font that will be used to render glyphs.
+    /// Referenced with `FontId(0)`, which is default.
+    pub fn using_font(font_0: Font<'a>) -> Self {
+        Self::using_fonts(vec![font_0])
+    }
+
+    /// Create a new builder with multiple fonts.
+    pub fn using_fonts<V: Into<Vec<Font<'a>>>>(fonts: V) -> Self {
+        let mut builder = Self::without_fonts();
+        builder.font_data = fonts.into();
+        builder
+    }
+
+    /// Create a new builder without any fonts.
+    ///
+    /// **Warning:** A [`GlyphBrushIndexed`] built without fonts will panic if you try to use it as it
+    /// will have no default `FontId(0)` to use.
+    /// Use [`GlyphBrushIndexed.add_font`] before queueing any text sections in order to avoid panicking.
+    ///
+    /// [`GlyphBrushIndexed`]: struct.GlyphBrushIndexed.html
+    /// [`GlyphBrushIndexed.add_font`]: ../glyph_brush/struct.GlyphBrushIndexed.html#method.add_font
+    pub fn without_fonts() -> Self {
+        GlyphBrushIndexedBuilder {
+            font_data: Vec::new(),
+            gpu_cache_builder: Cache::builder()
+                .dimensions(256, 256)
+                .scale_tolerance(0.5)
+                .position_tolerance(0.1)
+                .align_4x4(false),
+            _private_construction: (),
+        }
+    }
+}
+
+impl<'a> GlyphBrushIndexedBuilder<'a> {
+    /// Adds additional fonts to the one added in [`using_font`](#method.using_font) /
+    /// [`using_font_bytes`](#method.using_font_bytes).
+    /// Returns a [`FontId`](struct.FontId.html) to reference this font.
+    pub fn add_font_bytes<B: Into<SharedBytes<'a>>>(&mut self, font_data: B) -> FontId {
+        self.font_data
+            .push(Font::from_bytes(font_data.into()).unwrap());
+        FontId(self.font_data.len() - 1)
+    }
+
+    /// Adds additional fonts to the one added in [`using_font`](#method.using_font) /
+    /// [`using_font_bytes`](#method.using_font_bytes).
+    /// Returns a [`FontId`](struct.FontId.html) to reference this font.
+    pub fn add_font(&mut self, font_data: Font<'a>) -> FontId {
+        self.font_data.push(font_data);
+        FontId(self.font_data.len() - 1)
+    }
+
+    /// Consume all builder fonts a replace with new fonts returned by the input function.
+    ///
+    /// Generally only makes sense when wanting to change fonts after calling
+    /// [`GlyphBrushIndexed::to_builder`](struct.GlyphBrushIndexed.html#method.to_builder).
+    ///
+    /// # Example
+    /// ```
+    /// # use glyph_brush::{*, rusttype::*};
+    /// # type Vertex = ();
+    /// # let open_sans = Font::from_bytes(&include_bytes!("../../../fonts/DejaVuSans.ttf")[..]).unwrap();
+    /// # let deja_vu_sans = open_sans.clone();
+    /// let two_font_brush: GlyphBrushIndexed<'_, Vertex>
+    ///     = GlyphBrushIndexedBuilder::using_fonts(vec![open_sans, deja_vu_sans]).build();
+    ///
+    /// let one_font_brush: GlyphBrushIndexed<'_, Vertex> = two_font_brush
+    ///     .to_builder()
+    ///     .replace_fonts(|mut fonts| {
+    ///         // remove open_sans, leaving just deja_vu as FontId(0)
+    ///         fonts.remove(0);
+    ///         fonts
+    ///     })
+    ///     .build();
+    ///
+    /// assert_eq!(one_font_brush.fonts().len(), 1);
+    /// assert_eq!(two_font_brush.fonts().len(), 2);
+    /// ```
+    pub fn replace_fonts<V, F>(mut self, font_fn: F) -> Self
+    where
+        V: Into<Vec<Font<'a>>>,
+        F: FnOnce(Vec<Font<'a>>) -> V,
+    {
+        self.font_data = font_fn(self.font_data).into();
+        self
+    }
+
+    /// Initial size of 2D texture used as a gpu cache, pixels (width, height).
+    /// The GPU cache will dynamically quadruple in size whenever the current size
+    /// is insufficient.
+    ///
+    /// Defaults to `(256, 256)`
+    pub fn initial_cache_size(mut self, (w, h): (u32, u32)) -> Self {
+        self.gpu_cache_builder = self.gpu_cache_builder.dimensions(w, h);
+        self
+    }
+
+    /// Sets the maximum allowed difference in scale used for judging whether to reuse an
+    /// existing glyph in the GPU cache.
+    ///
+    /// Defaults to `0.5`
+    ///
+    /// See rusttype docs for `rusttype::gpu_cache::Cache`
+    pub fn gpu_cache_scale_tolerance(mut self, tolerance: f32) -> Self {
+        self.gpu_cache_builder = self.gpu_cache_builder.scale_tolerance(tolerance);
+        self
+    }
+
+    /// Sets the maximum allowed difference in subpixel position used for judging whether
+    /// to reuse an existing glyph in the GPU cache. Anything greater than or equal to
+    /// 1.0 means "don't care".
+    ///
+    /// Defaults to `0.1`
+    ///
+    /// See rusttype docs for `rusttype::gpu_cache::Cache`
+    pub fn gpu_cache_position_tolerance(mut self, tolerance: f32) -> Self {
+        self.gpu_cache_builder = self.gpu_cache_builder.position_tolerance(tolerance);
+        self
+    }
+
+    /// Align glyphs in texture cache to 4x4 texel boundaries.
+    ///
+    /// If your backend requires texture updates to be aligned to 4x4 texel
+    /// boundaries (e.g. WebGL), this should be set to `true`.
+    ///
+    /// Defaults to `false`
+    ///
+    /// See rusttype docs for `rusttype::gpu_cache::Cache`
+    pub fn gpu_cache_align_4x4(mut self, align: bool) -> Self {
+        self.gpu_cache_builder = self.gpu_cache_builder.align_4x4(align);
+        self
+    }
+
+    /// Builds a `GlyphBrushIndexed` using the input gfx factory
+    pub fn build<V>(self) -> GlyphBrushIndexed<'a, V> {
+        GlyphBrushIndexed {
+            fonts: self.font_data,
+            texture_cache: self.gpu_cache_builder.build(),
+
+            glyph_store: <_>::default(),
+
+            glyphs_custom_layout: None,
+        }
+    }
+
+    /// Rebuilds an existing `GlyphBrushIndexed` with this builder's properties. This will clear all
+    /// caches and queues.
+    ///
+    /// # Example
+    /// ```
+    /// # use glyph_brush::{*, rusttype::*};
+    /// # let sans = Font::from_bytes(&include_bytes!("../../../fonts/DejaVuSans.ttf")[..]).unwrap();
+    /// # type Vertex = ();
+    /// let mut glyph_brush: GlyphBrushIndexed<'_, Vertex> = GlyphBrushIndexedBuilder::using_font(sans).build();
+    /// assert_eq!(glyph_brush.texture_dimensions(), (256, 256));
+    ///
+    /// // Use a new builder to rebuild the brush with a smaller initial cache size
+    /// glyph_brush.to_builder().initial_cache_size((64, 64)).rebuild(&mut glyph_brush);
+    /// assert_eq!(glyph_brush.texture_dimensions(), (64, 64));
+    /// ```
+    pub fn rebuild<V>(self, brush: &mut GlyphBrushIndexed<'a, V>) {
+        std::mem::replace(brush, self.build());
+    }
+}

--- a/glyph-brush/src/lib.rs
+++ b/glyph-brush/src/lib.rs
@@ -32,12 +32,16 @@
 //! # }
 //! ```
 mod glyph_brush;
+mod glyph_brush_indexed;
 mod glyph_calculator;
 mod owned_section;
 mod section;
 
-pub use crate::{glyph_brush::*, glyph_calculator::*, owned_section::*, section::*};
+pub use crate::{
+    glyph_brush::*, glyph_brush_indexed::*, glyph_calculator::*, owned_section::*, section::*,
+};
 pub use glyph_brush_layout::*;
+use std::fmt;
 
 use glyph_brush_layout::rusttype::*;
 
@@ -74,3 +78,22 @@ fn default_section_hasher() {
     };
     assert_ne!(hash(&section_a), hash(&section_b));
 }
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BrushError {
+    /// Texture is too small to cache queued glyphs
+    ///
+    /// A larger suggested size is included.
+    TextureTooSmall { suggested: (u32, u32) },
+}
+impl fmt::Display for BrushError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BrushError::TextureTooSmall { .. } => {
+                write!(f, "Texture is too small to cache queued glyphs")?
+            }
+        }
+        Ok(())
+    }
+}
+impl std::error::Error for BrushError {}


### PR DESCRIPTION
In some cases we know exactly which sections we have and when we'll be
adding more or removing some sections. In such a case it's not worth
hashing, as it adds more complexity to the user - they need to re-queue
every section every time there's an update.

This patch introduces a new glyph-brush type that allows you to push and
pop sections by yourself, letting management of the indices be handled
by the user.