### PR TITLE
Add a custom generic to the sections that is copied to glyph vertices.

### DIFF
--- a/gfx-glyph/examples/depth.rs
+++ b/gfx-glyph/examples/depth.rs
@@ -99,6 +99,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                     font_id: italic_font,
                     layout: Layout::default().h_align(HorizontalAlign::Center),
                     z: 0.2,
+                    custom: (),
                 });
 
                 // 2nd section is drawn last but with higher z,

--- a/gfx-glyph/src/lib.rs
+++ b/gfx-glyph/src/lib.rs
@@ -177,7 +177,7 @@ pub struct GlyphBrush<'font, R: gfx::Resources, F: gfx::Factory<R>, H = DefaultS
     factory: F,
     program: gfx::handle::Program<R>,
     draw_cache: Option<DrawnGlyphBrush<R>>,
-    glyph_brush: glyph_brush::GlyphBrush<'font, GlyphVertex, H>,
+    glyph_brush: glyph_brush::GlyphBrush<'font, GlyphVertex, (), H>,
 
     // config
     depth_test: gfx::state::Depth,
@@ -190,7 +190,7 @@ impl<R: gfx::Resources, F: gfx::Factory<R>, H> fmt::Debug for GlyphBrush<'_, R, 
     }
 }
 
-impl<'font, R, F, H> GlyphCruncher<'font> for GlyphBrush<'font, R, F, H>
+impl<'font, R, F, H> GlyphCruncher<'font, ()> for GlyphBrush<'font, R, F, H>
 where
     R: gfx::Resources,
     F: gfx::Factory<R>,
@@ -204,7 +204,7 @@ where
     ) -> Option<Rect<i32>>
     where
         L: GlyphPositioner + Hash,
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, VariedSection<'a, ()>>>,
     {
         self.glyph_brush
             .pixel_bounds_custom_layout(section, custom_layout)
@@ -218,7 +218,7 @@ where
     ) -> PositionedGlyphIter<'b, 'font>
     where
         L: GlyphPositioner + Hash,
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, VariedSection<'a, ()>>>,
     {
         self.glyph_brush
             .glyphs_custom_layout(section, custom_layout)
@@ -244,7 +244,7 @@ where
     #[inline]
     pub fn queue<'a, S>(&mut self, section: S)
     where
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, VariedSection<'a, ()>>>,
     {
         self.glyph_brush.queue(section)
     }
@@ -293,7 +293,7 @@ where
     pub fn queue_custom_layout<'a, S, G>(&mut self, section: S, custom_layout: &G)
     where
         G: GlyphPositioner,
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, VariedSection<'a, ()>>>,
     {
         self.glyph_brush.queue_custom_layout(section, custom_layout)
     }
@@ -307,7 +307,7 @@ where
         bounds: Rect<f32>,
         z: f32,
     ) {
-        self.glyph_brush.queue_pre_positioned(glyphs, bounds, z)
+        self.glyph_brush.queue_pre_positioned(glyphs, bounds, z, ())
     }
 
     /// Retains the section in the cache as if it had been used in the last draw-frame.
@@ -317,7 +317,7 @@ where
     #[inline]
     pub fn keep_cached_custom_layout<'a, S, G>(&mut self, section: S, custom_layout: &G)
     where
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, VariedSection<'a, ()>>>,
         G: GlyphPositioner,
     {
         self.glyph_brush
@@ -331,7 +331,7 @@ where
     #[inline]
     pub fn keep_cached<'a, S>(&mut self, section: S)
     where
-        S: Into<Cow<'a, VariedSection<'a>>>,
+        S: Into<Cow<'a, VariedSection<'a, ()>>>,
     {
         self.glyph_brush.keep_cached(section)
     }
@@ -603,7 +603,8 @@ fn to_vertex(
         bounds,
         color,
         z,
-    }: glyph_brush::GlyphVertex,
+        custom: (),
+    }: glyph_brush::GlyphVertex<()>,
 ) -> GlyphVertex {
     let gl_bounds = bounds;
 

--- a/glyph-brush-layout/src/lib.rs
+++ b/glyph-brush-layout/src/lib.rs
@@ -31,18 +31,19 @@
 //!             scale: Scale::uniform(25.0),
 //!             font_id: FontId(1),
 //!             color: [0.0, 1.0, 0.0, 1.0],
+//!             custom: ()
 //!         },
 //!     ],
 //! );
 //!
 //! assert_eq!(glyphs.len(), 23);
 //!
-//! let (o_glyph, glyph_4_color, glyph_4_font) = &glyphs[4];
+//! let (o_glyph, glyph_4_color, glyph_4_font, ()) = &glyphs[4];
 //! assert_eq!(o_glyph.id(), fonts[0].glyph('o').id());
 //! assert_eq!(*glyph_4_color, [0.0, 0.0, 0.0, 1.0]);
 //! assert_eq!(*glyph_4_font, FontId(0));
 //!
-//! let (s_glyph, glyph_14_color, glyph_14_font) = &glyphs[14];
+//! let (s_glyph, glyph_14_color, glyph_14_font, ()) = &glyphs[14];
 //! assert_eq!(s_glyph.id(), fonts[1].glyph('s').id());
 //! assert_eq!(*glyph_14_color, [0.0, 1.0, 0.0, 1.0]);
 //! assert_eq!(*glyph_14_font, FontId(1));
@@ -78,12 +79,12 @@ use std::hash::Hash;
 pub trait GlyphPositioner: Hash {
     /// Calculate a sequence of positioned glyphs to render. Custom implementations should
     /// return the same result when called with the same arguments to allow layout caching.
-    fn calculate_glyphs<'font, F: FontMap<'font>>(
+    fn calculate_glyphs<'font, F: FontMap<'font>, C: Clone>(
         &self,
         fonts: &F,
         geometry: &SectionGeometry,
-        sections: &[SectionText<'_>],
-    ) -> Vec<(PositionedGlyph<'font>, Color, FontId)>;
+        sections: &[SectionText<'_, C>],
+    ) -> Vec<(PositionedGlyph<'font>, Color, FontId, C)>;
 
     /// Return a screen rectangle according to the requested render position and bounds
     /// appropriate for the glyph layout.
@@ -93,14 +94,14 @@ pub trait GlyphPositioner: Hash {
     ///
     /// The default implementation simply calls `calculate_glyphs` so must be implemented
     /// to provide benefits as such benefits are spefic to the internal layout logic.
-    fn recalculate_glyphs<'font, F>(
+    fn recalculate_glyphs<'font, F, C: Clone>(
         &self,
-        previous: Cow<'_, Vec<(PositionedGlyph<'font>, Color, FontId)>>,
+        previous: Cow<'_, Vec<(PositionedGlyph<'font>, Color, FontId, C)>>,
         change: GlyphChange,
         fonts: &F,
         geometry: &SectionGeometry,
-        sections: &[SectionText<'_>],
-    ) -> Vec<(PositionedGlyph<'font>, Color, FontId)>
+        sections: &[SectionText<'_, C>],
+    ) -> Vec<(PositionedGlyph<'font>, Color, FontId, C)>
     where
         F: FontMap<'font>,
     {

--- a/glyph-brush-layout/src/section.rs
+++ b/glyph-brush-layout/src/section.rs
@@ -23,7 +23,7 @@ impl Default for SectionGeometry {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct SectionText<'a> {
+pub struct SectionText<'a, C> {
     /// Text to render
     pub text: &'a str,
     /// Position on screen to render text, in pixels from top-left. Defaults to (0, 0).
@@ -36,9 +36,10 @@ pub struct SectionText<'a> {
     /// either `FontId::default()` or the return of
     /// [`add_font`](struct.GlyphBrushBuilder.html#method.add_font).
     pub font_id: FontId,
+    pub custom: C
 }
 
-impl Default for SectionText<'static> {
+impl<C: Default> Default for SectionText<'static, C> {
     #[inline]
     fn default() -> Self {
         Self {
@@ -46,6 +47,7 @@ impl Default for SectionText<'static> {
             scale: Scale::uniform(16.0),
             color: [0.0, 0.0, 0.0, 1.0],
             font_id: FontId::default(),
+            custom: C::default()
         }
     }
 }

--- a/glyph-brush/benches/bench.rs
+++ b/glyph-brush/benches/bench.rs
@@ -623,9 +623,9 @@ fn continually_modify_position_of_1_of_3(c: &mut Criterion) {
 fn bench_variants<'a, S: 'a>(
     b: &mut Bencher,
     variants: &'a [std::vec::Vec<S>],
-    glyph_brush: &mut GlyphBrush<'_, [f32; 13]>,
+    glyph_brush: &mut GlyphBrush<'_, [f32; 13], ()>,
 ) where
-    &'a S: Into<Cow<'a, VariedSection<'a>>>,
+    &'a S: Into<Cow<'a, VariedSection<'a, ()>>>,
 {
     let mut variants = variants.iter().cycle();
 
@@ -648,7 +648,8 @@ fn gl_to_vertex(
         bounds,
         color,
         z,
-    }: glyph_brush::GlyphVertex,
+        custom: (),
+    }: glyph_brush::GlyphVertex<()>,
 ) -> [f32; 13] {
     let gl_bounds = bounds;
 

--- a/glyph-brush/examples/opengl.rs
+++ b/glyph-brush/examples/opengl.rs
@@ -435,7 +435,8 @@ fn to_vertex(
         bounds,
         color,
         z,
-    }: glyph_brush::GlyphVertex,
+        custom: _
+    }: glyph_brush::GlyphVertex<()>,
 ) -> Vertex {
     let gl_bounds = bounds;
 

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -85,7 +85,7 @@ impl<'font, V, C, H> GlyphCruncher<'font, C> for GlyphBrush<'font, V, C, H>
 where
     V: Clone + 'static,
     H: BuildHasher,
-    C: Clone,
+    C: Clone + Hash,
 {
     fn pixel_bounds_custom_layout<'a, S, L>(
         &mut self,
@@ -130,7 +130,7 @@ impl<'font, V, C, H> GlyphBrush<'font, V, C, H>
 where
     V: Clone + 'static,
     H: BuildHasher,
-    C: Clone,
+    C: Clone + Hash,
 {
     /// Queues a section/layout to be processed by the next call of
     /// [`process_queued`](struct.GlyphBrush.html#method.process_queued). Can be called multiple
@@ -605,7 +605,7 @@ impl SectionHashDetail {
     where
         H: BuildHasher,
         L: GlyphPositioner,
-        C: Clone,
+        C: Clone + Hash,
     {
         let parts = section.to_hashable_parts();
 
@@ -622,6 +622,7 @@ impl SectionHashDetail {
 
         parts.hash_geometry(&mut s);
         parts.hash_z(&mut s);
+        parts.hash_custom(&mut s);
         let full_hash = s.finish();
 
         Self {

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -11,7 +11,7 @@ use std::hash::BuildHasher;
 /// # type Vertex = ();
 ///
 /// let dejavu: &[u8] = include_bytes!("../../../fonts/DejaVuSans.ttf");
-/// let mut glyph_brush: GlyphBrush<'_, Vertex> =
+/// let mut glyph_brush: GlyphBrush<'_, Vertex, ()> =
 ///     GlyphBrushBuilder::using_font_bytes(dejavu).build();
 /// ```
 pub struct GlyphBrushBuilder<'a, H = DefaultSectionHasher> {
@@ -110,10 +110,10 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
     /// # type Vertex = ();
     /// # let open_sans = Font::from_bytes(&include_bytes!("../../../fonts/DejaVuSans.ttf")[..]).unwrap();
     /// # let deja_vu_sans = open_sans.clone();
-    /// let two_font_brush: GlyphBrush<'_, Vertex>
+    /// let two_font_brush: GlyphBrush<'_, Vertex, ()>
     ///     = GlyphBrushBuilder::using_fonts(vec![open_sans, deja_vu_sans]).build();
     ///
-    /// let one_font_brush: GlyphBrush<'_, Vertex> = two_font_brush
+    /// let one_font_brush: GlyphBrush<'_, Vertex, ()> = two_font_brush
     ///     .to_builder()
     ///     .replace_fonts(|mut fonts| {
     ///         // remove open_sans, leaving just deja_vu as FontId(0)
@@ -234,7 +234,7 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
     }
 
     /// Builds a `GlyphBrush` using the input gfx factory
-    pub fn build<V>(self) -> GlyphBrush<'a, V, H> {
+    pub fn build<V, C>(self) -> GlyphBrush<'a, V, C, H> {
         GlyphBrush {
             fonts: self.font_data,
             texture_cache: self.gpu_cache_builder.build(),
@@ -266,14 +266,14 @@ impl<'a, H: BuildHasher> GlyphBrushBuilder<'a, H> {
     /// # use glyph_brush::{*, rusttype::*};
     /// # let sans = Font::from_bytes(&include_bytes!("../../../fonts/DejaVuSans.ttf")[..]).unwrap();
     /// # type Vertex = ();
-    /// let mut glyph_brush: GlyphBrush<'_, Vertex> = GlyphBrushBuilder::using_font(sans).build();
+    /// let mut glyph_brush: GlyphBrush<'_, Vertex, ()> = GlyphBrushBuilder::using_font(sans).build();
     /// assert_eq!(glyph_brush.texture_dimensions(), (256, 256));
     ///
     /// // Use a new builder to rebuild the brush with a smaller initial cache size
     /// glyph_brush.to_builder().initial_cache_size((64, 64)).rebuild(&mut glyph_brush);
     /// assert_eq!(glyph_brush.texture_dimensions(), (64, 64));
     /// ```
-    pub fn rebuild<V>(self, brush: &mut GlyphBrush<'a, V, H>) {
+    pub fn rebuild<V, C>(self, brush: &mut GlyphBrush<'a, V, C, H>) {
         std::mem::replace(brush, self.build());
     }
 }

--- a/glyph-brush/src/lib.rs
+++ b/glyph-brush/src/lib.rs
@@ -3,7 +3,7 @@
 //!
 //! # fn main() -> Result<(), glyph_brush::BrushError> {
 //! let dejavu: &[u8] = include_bytes!("../../fonts/DejaVuSans.ttf");
-//! let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(dejavu).build();
+//! let mut glyph_brush = GlyphBrushBuilder::using_font_bytes(dejavu).build::<(), ()>();
 //! # let some_other_section = Section { text: "another", ..Section::default() };
 //!
 //! glyph_brush.queue(Section {
@@ -66,8 +66,8 @@ fn default_section_hasher() {
         color: [1.0, 1.0, 1.0, 1.0],
         ..<_>::default()
     };
-    let hash = |s: &Section| {
-        let s: VariedSection = s.into();
+    let hash = |s: &Section<()>| {
+        let s: VariedSection<_> = s.into();
         let mut hasher = DefaultSectionHasher::default().build_hasher();
         s.hash(&mut hasher);
         hasher.finish()

--- a/glyph-brush/src/owned_section.rs
+++ b/glyph-brush/src/owned_section.rs
@@ -13,11 +13,10 @@ pub struct OwnedVariedSection<C> {
     /// see [`queue_custom_layout`](struct.GlyphBrush.html#method.queue_custom_layout)
     pub layout: Layout<BuiltInLineBreaker>,
     /// Text to render, rendered next to one another according the layout.
-    pub text: Vec<OwnedSectionText>,
-    pub custom: C,
+    pub text: Vec<OwnedSectionText<C>>,
 }
 
-impl<C: Default> Default for OwnedVariedSection<C> {
+impl<C> Default for OwnedVariedSection<C> {
     fn default() -> Self {
         Self {
             screen_position: (0.0, 0.0),
@@ -25,7 +24,6 @@ impl<C: Default> Default for OwnedVariedSection<C> {
             z: 0.0,
             layout: Layout::default(),
             text: vec![],
-            custom: C::default()
         }
     }
 }
@@ -38,7 +36,6 @@ impl<C: Clone> OwnedVariedSection<C> {
             z: self.z,
             layout: self.layout,
             text: self.text.iter().map(|t| t.into()).collect(),
-            custom: self.custom.clone(),
         }
     }
 }
@@ -56,7 +53,7 @@ impl<'a, C: Clone> From<&'a OwnedVariedSection<C>> for Cow<'a, VariedSection<'a,
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct OwnedSectionText {
+pub struct OwnedSectionText<C> {
     /// Text to render
     pub text: String,
     /// Position on screen to render text, in pixels from top-left. Defaults to (0, 0).
@@ -69,37 +66,41 @@ pub struct OwnedSectionText {
     /// either `FontId::default()` or the return of
     /// [`add_font`](struct.GlyphBrushBuilder.html#method.add_font).
     pub font_id: FontId,
+    custom: C
 }
 
-impl Default for OwnedSectionText {
+impl<C: Default> Default for OwnedSectionText<C> {
     fn default() -> Self {
         Self {
             text: String::new(),
             scale: Scale::uniform(16.0),
             color: [0.0, 0.0, 0.0, 1.0],
             font_id: FontId::default(),
+            custom: C::default()
         }
     }
 }
 
-impl<'a> From<&'a OwnedSectionText> for SectionText<'a> {
-    fn from(owned: &'a OwnedSectionText) -> Self {
+impl<'a, C: Clone> From<&'a OwnedSectionText<C>> for SectionText<'a, C> {
+    fn from(owned: &'a OwnedSectionText<C>) -> Self {
         Self {
             text: owned.text.as_str(),
             scale: owned.scale,
             color: owned.color,
             font_id: owned.font_id,
+            custom: owned.custom.clone(),
         }
     }
 }
 
-impl From<&SectionText<'_>> for OwnedSectionText {
-    fn from(st: &SectionText<'_>) -> Self {
+impl<C: Clone> From<&SectionText<'_, C>> for OwnedSectionText<C> {
+    fn from(st: &SectionText<'_, C>) -> Self {
         Self {
             text: st.text.into(),
             scale: st.scale,
             color: st.color,
             font_id: st.font_id,
+            custom: st.custom.clone(),
         }
     }
 }

--- a/glyph-brush/src/owned_section.rs
+++ b/glyph-brush/src/owned_section.rs
@@ -2,7 +2,7 @@ use super::*;
 use std::{borrow::Cow, f32};
 
 #[derive(Debug, Clone, PartialEq)]
-pub struct OwnedVariedSection {
+pub struct OwnedVariedSection<C> {
     /// Position on screen to render text, in pixels from top-left. Defaults to (0, 0).
     pub screen_position: (f32, f32),
     /// Max (width, height) bounds, in pixels from top-left. Defaults to unbounded.
@@ -14,9 +14,10 @@ pub struct OwnedVariedSection {
     pub layout: Layout<BuiltInLineBreaker>,
     /// Text to render, rendered next to one another according the layout.
     pub text: Vec<OwnedSectionText>,
+    pub custom: C,
 }
 
-impl Default for OwnedVariedSection {
+impl<C: Default> Default for OwnedVariedSection<C> {
     fn default() -> Self {
         Self {
             screen_position: (0.0, 0.0),
@@ -24,30 +25,32 @@ impl Default for OwnedVariedSection {
             z: 0.0,
             layout: Layout::default(),
             text: vec![],
+            custom: C::default()
         }
     }
 }
 
-impl OwnedVariedSection {
-    pub fn to_borrowed(&self) -> VariedSection<'_> {
+impl<C: Clone> OwnedVariedSection<C> {
+    pub fn to_borrowed(&self) -> VariedSection<'_, C> {
         VariedSection {
             screen_position: self.screen_position,
             bounds: self.bounds,
             z: self.z,
             layout: self.layout,
             text: self.text.iter().map(|t| t.into()).collect(),
+            custom: self.custom.clone(),
         }
     }
 }
 
-impl<'a> From<&'a OwnedVariedSection> for VariedSection<'a> {
-    fn from(owned: &'a OwnedVariedSection) -> Self {
+impl<'a, C: Clone> From<&'a OwnedVariedSection<C>> for VariedSection<'a, C> {
+    fn from(owned: &'a OwnedVariedSection<C>) -> Self {
         owned.to_borrowed()
     }
 }
 
-impl<'a> From<&'a OwnedVariedSection> for Cow<'a, VariedSection<'a>> {
-    fn from(owned: &'a OwnedVariedSection) -> Self {
+impl<'a, C: Clone> From<&'a OwnedVariedSection<C>> for Cow<'a, VariedSection<'a, C>> {
+    fn from(owned: &'a OwnedVariedSection<C>) -> Self {
         Cow::Owned(owned.to_borrowed())
     }
 }

--- a/glyph-brush/src/owned_section.rs
+++ b/glyph-brush/src/owned_section.rs
@@ -66,7 +66,7 @@ pub struct OwnedSectionText<C> {
     /// either `FontId::default()` or the return of
     /// [`add_font`](struct.GlyphBrushBuilder.html#method.add_font).
     pub font_id: FontId,
-    custom: C
+    pub custom: C
 }
 
 impl<C: Default> Default for OwnedSectionText<C> {

--- a/glyph-brush/src/section.rs
+++ b/glyph-brush/src/section.rs
@@ -135,7 +135,7 @@ impl<'text, C: Clone> VariedSection<'text, C> {
         }
     }
 
-    pub(crate) fn to_hashable_parts(&self) -> HashableVariedSectionParts<'_> {
+    pub(crate) fn to_hashable_parts(&self) -> HashableVariedSectionParts<'_, C> {
         let VariedSection {
             screen_position: (screen_x, screen_y),
             bounds: (bound_w, bound_h),
@@ -155,6 +155,7 @@ impl<'text, C: Clone> VariedSection<'text, C> {
             geometry,
             z: z.into(),
             text,
+            custom: self.custom.clone(),
         }
     }
 }
@@ -273,13 +274,14 @@ impl<'a, C: Clone> From<&Section<'a, C>> for Cow<'a, VariedSection<'a, C>> {
     }
 }
 
-pub(crate) struct HashableVariedSectionParts<'a> {
+pub(crate) struct HashableVariedSectionParts<'a, C> {
     geometry: [OrderedFloat<f32>; 4],
     z: OrderedFloat<f32>,
     text: &'a [SectionText<'a>],
+    custom: C,
 }
 
-impl HashableVariedSectionParts<'_> {
+impl<C> HashableVariedSectionParts<'_, C> {
     #[inline]
     pub fn hash_geometry<H: Hasher>(&self, state: &mut H) {
         self.geometry.hash(state);
@@ -323,5 +325,10 @@ impl HashableVariedSectionParts<'_> {
 
             ord_floats.hash(state);
         }
+    }
+
+    #[inline]
+    pub fn hash_custom<H: Hasher>(&self, state: &mut H) where C: Hash {
+        self.custom.hash(state);
     }
 }


### PR DESCRIPTION
In order for users of this library (`gfx-glyph`, `wgpu_glyph` etc.) to implement custom rendering instructions for sections (rotation, [pixelation](https://github.com/alexheretic/glyph-brush/issues/99), etc.), this PR adds a generic `custom` field to many structs. This field is needs to implement `Clone` and `Hash` and is copied from a section into a `GlyphVertex`.

This would also allow us to move information needed for rendering such as `Color` and the `z` depth from `glyph-brush` into `gfx-glyph` etc. The disadvantage of doing this is obviously that you have this generic `C` parameter everywhere, which worsens readability somewhat.