### PR TITLE
Add GlyphBrush::drawn_rect_at

### DIFF
--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -547,6 +547,18 @@ where
     pub fn is_draw_cached(&self, font_id: FontId, glyph: &Glyph) -> bool {
         self.texture_cache.rect_for(font_id.0, glyph).is_some()
     }
+
+    /// Returns the Some-Rect position the glyph has drawn, if this glyph is currently present
+    /// in the draw cache texture.
+    ///
+    /// So None means either this glyph is invisible, like `' '`, or hasn't been queued &
+    /// processed yet.
+    #[inline]
+    pub fn drawn_rect_at(&self, font_id: FontId, glyph: &Glyph) -> Option<Rect> {
+        self.texture_cache
+            .rect_for(font_id.0, glyph)
+            .map(|(_, rect)| rect)
+    }
 }
 
 impl<F: Font + Clone, V, X, H: BuildHasher + Clone> GlyphBrush<V, X, F, H> {
@@ -863,5 +875,39 @@ mod glyph_brush_test {
         assert!(brush.is_draw_cached(FontId(1), &glyphs[2]));
         assert!(!brush.is_draw_cached(FontId(1), &glyphs[3]));
         assert!(!brush.is_draw_cached(FontId(0), &unqueued_glyph));
+    }
+
+    #[test]
+    fn drawn_rect_at() {
+        let font_a = FontRef::try_from_slice(include_bytes!("../../fonts/DejaVuSans.ttf")).unwrap();
+        let font_b = FontRef::try_from_slice(include_bytes!("../../fonts/Exo2-Light.otf")).unwrap();
+        let unqueued_glyph = font_a.glyph_id('c').with_scale(50.0);
+
+        let mut brush = GlyphBrushBuilder::using_fonts(vec![font_a, font_b]).build();
+
+        let section = Section::default()
+            .add_text(Text::new("a "))
+            .add_text(Text::new("b ").with_font_id(FontId(1)));
+
+        brush.queue(&section);
+        let glyphs: Vec<_> = brush.glyphs(section).map(|sg| sg.glyph.clone()).collect();
+
+        assert_eq!(glyphs.len(), 4);
+
+        // nothing was cached because `process_queued` has not been called yet.
+        assert!(brush.drawn_rect_at(FontId(0), &glyphs[0]).is_none());
+        assert!(brush.drawn_rect_at(FontId(0), &glyphs[1]).is_none());
+        assert!(brush.drawn_rect_at(FontId(1), &glyphs[2]).is_none());
+        assert!(brush.drawn_rect_at(FontId(1), &glyphs[3]).is_none());
+        assert!(brush.drawn_rect_at(FontId(0), &unqueued_glyph).is_none());
+
+        brush.process_queued(|_, _| {}, |_| ()).unwrap();
+
+        // visible glyphs that were queued have now been cached.
+        assert!(brush.drawn_rect_at(FontId(0), &glyphs[0]).is_some());
+        assert!(brush.drawn_rect_at(FontId(0), &glyphs[1]).is_none());
+        assert!(brush.drawn_rect_at(FontId(1), &glyphs[2]).is_some());
+        assert!(brush.drawn_rect_at(FontId(1), &glyphs[3]).is_none());
+        assert!(brush.drawn_rect_at(FontId(0), &unqueued_glyph).is_none());
     }
 }


### PR DESCRIPTION
Export the rect position the glyph has drawn, if this glyph is currently present in the draw cache texture.