### PR TITLE
Do not use word-wrapping in single-line mode

### DIFF
--- a/gfx-glyph/examples/paragraph.rs
+++ b/gfx-glyph/examples/paragraph.rs
@@ -80,7 +80,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut font_size: f32 = 18.0;
     let mut zoom: f32 = 1.0;
     let mut angle = 0.0;
-    let mut ctrl = false;
     let mut loop_helper = spin_sleep::LoopHelper::builder().build_with_target_rate(250.0);
 
     let mut modifiers = ModifiersState::default();
@@ -116,17 +115,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                     VirtualKeyCode::Back => {
                         text.pop();
                     }
-                    VirtualKeyCode::LControl | VirtualKeyCode::RControl => ctrl = true,
                     _ => (),
                 },
-                WindowEvent::KeyboardInput {
-                    input:
-                        KeyboardInput {
-                            state: ElementState::Released,
-                            ..
-                        },
-                    ..
-                } => ctrl = false,
                 WindowEvent::ReceivedCharacter(c) => {
                     if c != '\u{7f}' && c != '\u{8}' {
                         text.push(c);

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -341,8 +341,8 @@ where
             let active = mem::take(&mut self.keep_in_cache);
             self.calculate_glyph_cache
                 .retain(|key, _| active.contains(key));
-            mem::replace(&mut self.keep_in_cache, active);
 
+            self.keep_in_cache = active;
             self.keep_in_cache.clear();
 
             self.section_buffer.clear();

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -246,7 +246,7 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
     /// assert_eq!(glyph_brush.texture_dimensions(), (64, 64));
     /// ```
     pub fn rebuild<V, X>(self, brush: &mut GlyphBrush<V, X, F, H>) {
-        std::mem::replace(brush, self.build());
+        *brush = self.build();
     }
 }
 

--- a/layout/src/characters.rs
+++ b/layout/src/characters.rs
@@ -6,7 +6,6 @@ use crate::{
 use ab_glyph::*;
 use std::{
     iter::{Enumerate, FusedIterator, Iterator},
-    mem,
     str::CharIndices,
 };
 
@@ -118,7 +117,7 @@ where
                     loop {
                         let next = line_breaks.next();
                         if next.is_none() || next.unwrap().offset() > byte_index {
-                            mem::replace(next_break, next);
+                            *next_break = next;
                             break;
                         }
                     }


### PR DESCRIPTION
Currently, when word-wrapping is disabled, glyph-brush-layout will omit any word after the first which can only partially appear on the line (as is usually the case with line-wrapping). This PR changes that to include the next full word. It could maybe be better (omit letters which are fully outside the bounds, perhaps a nicer way of drawing cut-off text).

Rationale: when writing text into a single-line edit box, normally one does not expect a word to be hidden because it doesn't fully fit on the line. This doesn't fix everything (e.g. horizontal scrolling within the edit box), but is an improvement. (One can test with [KAS 0.4](https://github.com/kas-gui/kas/tree/0.4.1) using the `gallery` example.)

Two tests fail; I wasn't sure how best to fix these:
```
---- builtin::layout_test::single_line_limited_horizontal_room stdout ----
thread 'builtin::layout_test::single_line_limited_horizontal_room' panicked at 'assertion failed: `(left == right)`
  left: `"hell"`,
 right: `"hello"`', layout/src/builtin.rs:664:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- builtin::layout_test::wrap_word_left stdout ----
thread 'builtin::layout_test::wrap_word_left' panicked at 'assertion failed: `(left == right)`
  left: `"hello "`,
 right: `"hello what\'s _happening_☐"`', layout/src/builtin.rs:615:9
```