### PR TITLE
Add new option: cpu_cache

### DIFF
--- a/draw-cache/src/lib.rs
+++ b/draw-cache/src/lib.rs
@@ -40,7 +40,7 @@ pub mod ab_glyph {
 
 pub use geometry::Rectangle;
 
-use ::ab_glyph::*;
+use crate::ab_glyph::*;
 use linked_hash_map::LinkedHashMap;
 #[cfg(not(target_arch = "wasm32"))]
 use rayon::prelude::*;
@@ -814,11 +814,10 @@ impl DrawCache {
             }
 
             if queue_success {
-                #[cfg(not(target_arch = "wasm32"))]
                 {
                     let glyph_count = draw_and_upload.len();
 
-                    if self.multithread && glyph_count > 1 {
+                    if self.multithread && glyph_count > 1 && cfg!(not(target_arch = "wasm32")) {
                         // multithread rasterization
                         use crossbeam_channel::TryRecvError;
                         use crossbeam_deque::Worker;
@@ -904,13 +903,6 @@ impl DrawCache {
                             let pixels = draw_glyph(tex_coords, &outlined, self.pad_glyphs);
                             uploader(tex_coords, pixels.as_slice());
                         }
-                    }
-                }
-                #[cfg(target_arch = "wasm32")]
-                {
-                    for (tex_coords, outlined) in draw_and_upload {
-                        let pixels = draw_glyph(tex_coords, &outlined, self.pad_glyphs);
-                        uploader(tex_coords, pixels.as_slice());
                     }
                 }
             }


### PR DESCRIPTION
Hi Alex, thanks for the super useful library!

I've been using glyph-brush (and previously `rusttype::gpu_cache`) with [wgpu-rs](https://github.com/gfx-rs/wgpu-rs). I was doing so by calling [the `CommandEncoder` method `copy_buffer_to_texture`](https://docs.rs/wgpu/0.6.0/wgpu/struct.CommandEncoder.html#method.copy_buffer_to_texture) for each value returned by `cache_queued`. When I updated wgpu to version 0.6.0, I hit a snag, as it started enforcing buffer copies to align to 256 bytes. 

I had also previously noticed that this strategy came with some performance problems as well, as it required one copy to the GPU per changed glyph. So when rendering 100 glyphs for the first time, the result was 14.1ms time spent caching glyphs, the majority of which was spent in these GPU operations:
![`rusttype::gpu_cache`](https://user-images.githubusercontent.com/402791/93033138-d2244980-f5e9-11ea-9ea2-76e7b02861a4.png)
(sorry, it's a little hard to see where the time is going there, but all of those `wgpu` operations there under the `update_font_cache::{{closure}}` are the buffer-to-texture copies)

To help solve both of these problems (after switching to glyph_brush_draw_cache), I added a new option: `cpu_cache`. From the rust doc comment on the option:

> Cache the rasterized glyphs in CPU-side memory. When enabled, `cache_queued` will return any _rows_ of glyphs that have been updated (as opposed to individual glyphs). When multiple contiguous rows are updated, they are sent to the `cache_queued` user-supplied `uploader` function as a single chunk. The result is a minimization of calls to `uploader`, which in turn can minimize the number of write operations to one's GPU cache.

The result is this draft PR. Now rendering 100 glyphs for the first time takes 5.6ms, with my profiler not even registering the copy-to-texture operation:
![`glyph_bruch_draw_cache` with `cpu_cache`](https://user-images.githubusercontent.com/402791/93032042-039a1680-f5e4-11ea-9dee-d644e63a90d5.png)

If you think this approach has legs, then I'll do the work to get this working with the `multithread` option and add some tests. Thanks!
