### PR TITLE
Draw-cache: Optimise empty cache-queued into single texture upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,14 @@ jobs:
     - uses: actions/checkout@v2
     - run: cargo test --target i686-unknown-linux-musl
 
+  check_wasm:
+    runs-on: ubuntu-latest
+    steps:
+    - run: rustup update stable
+    - run: rustup target add wasm32-unknown-unknown
+    - uses: actions/checkout@v2
+    - run: cargo check --target wasm32-unknown-unknown
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:

--- a/draw-cache/CHANGELOG.md
+++ b/draw-cache/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Optimise empty cache `cache_queued` calls by bundling texture data into a single upload.
+
 # 0.1.1
 * Require _ab_glyph_ 0.2.2.
 

--- a/test
+++ b/test
@@ -5,6 +5,8 @@ set -eu
 dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd "$dir"
 
+echo "==> check wasm32-unknown-unknown"
+cargo check --target wasm32-unknown-unknown --target-dir ./target/wasm/
 echo "==> test"
 cargo test
 cargo test --benches


### PR DESCRIPTION
This PR adds an optimisation targeting whenever the cache is empty & multiple new glyphs have been drawn in a call to `cache_queued`, e.g. the initial population of the cache & when it must be re-orded to fit all glyphs after a change.

In this case total in-use region of the texture will be saved in memory during the `cache_queued(self, fonts, uploader)` call and provided with a single callback to `uploader`. This minimises uploads to the gpu in common cases which should be faster.

`cache_queued` calls to a non-empty cache are not effected.

### Benchmarks
The draw-cache v2 benchmarks simulate gpu uploads by busy waiting for 4us, this allows us to benchmark this improvement in a artificial way.

Non-populating benchmarks were not effected, as expected. Populating & reordering benchmarks were:
* `multi_font_population_v2` **-63.5%**
* `resizing_v2` **-59.1%**
* `moving_text_thrashing_v2` **-58.3%**

Related to discussion in #120 