### PR TITLE
Add GlyphBrushBuilder::multithread config

### DIFF
--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Add `GlyphBrushBuilder::multithread` to allow setting the (default on) draw-cache multithreading.
+
 # 0.7.1
 * Update _ordered-float_ to `2`.
 

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -136,6 +136,14 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
         self
     }
 
+    /// When multiple CPU cores are available spread draw-cache work across all cores.
+    ///
+    /// Defaults to `true`.
+    pub fn multithread(mut self, multithread: bool) -> Self {
+        self.draw_cache_builder = self.draw_cache_builder.multithread(multithread);
+        self
+    }
+
     /// Align glyphs in texture cache to 4x4 texel boundaries.
     ///
     /// If your backend requires texture updates to be aligned to 4x4 texel


### PR DESCRIPTION
Add `GlyphBrushBuilder::multithread` to allow setting the (default on) draw-cache multithreading.

Related to #125 