### PR TITLE
Keep word trailing space width, if the word ends in a hard break

### DIFF
--- a/layout/CHANGELOG.md
+++ b/layout/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Default layouts: Keep word trailing space width if ending in a hard break _e.g. `"Foo  \n"`_.
+
 # 0.2.2
 * Update _approx_ to `0.5`.
 

--- a/layout/src/lines.rs
+++ b/layout/src/lines.rs
@@ -97,7 +97,14 @@ where
         let mut progressed = false;
 
         while let Some(word) = self.words.peek() {
-            let word_right = caret.x + word.layout_width_no_trail;
+            // Drop trailing spaces when bounds-wrapping.
+            // However, if the word ends in a hard-break "Foo  \n" keep the trailing space width.
+            let word_wrap_width = match word.hard_break {
+                false => word.layout_width_no_trail,
+                true => word.layout_width,
+            };
+
+            let word_right = caret.x + word_wrap_width;
             // Reduce float errors by using relative "<= width bound" check
             let word_in_bounds =
                 word_right < self.width_bound || approx::relative_eq!(word_right, self.width_bound);


### PR DESCRIPTION
One possible improvement from the #130 discussion. I'm not 100% that this is correct though...

* [x] Update readme