### PR TITLE
disable default features for ordered-float

### DIFF
--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -13,7 +13,7 @@ readme="README.md"
 glyph_brush_layout = { version = "0.2", path = "../layout" }
 glyph_brush_draw_cache = { version = "0.1.1", path = "../draw-cache" }
 log = "0.4.4"
-ordered-float = "2"
+ordered-float = { version = "2", default-features = false }
 rustc-hash = "1"
 twox-hash = "1"
 


### PR DESCRIPTION
Hi!

`ordered-float` recently added `rand` as a default but optional dependency. https://github.com/reem/rust-ordered-float/pull/84

This causes this crate to no longer compile on the `wasm32-unknown-unknown` target.

Since none of the default features are being used, it made more sense to me to disable than than to pin to an earlier version of the dependency.

Thanks for your crate!