### PR TITLE
Keep trailing space at end of glyphs

### DIFF
--- a/layout/CHANGELOG.md
+++ b/layout/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Unreleased
-* Default layouts: Keep word trailing space width if ending in a hard break _e.g. `"Foo  \n"`_.
+* Default layouts: Keep word trailing space width if ending in a hard break or end of all glyphs _e.g. `"Foo  \n"`_.
 
 # 0.2.2
 * Update _approx_ to `0.5`.

--- a/layout/src/builtin.rs
+++ b/layout/src/builtin.rs
@@ -965,7 +965,7 @@ mod layout_test {
     }
 
     /// #130 - Respect trailing whitespace in words if directly preceeding a hard break.
-    /// So wrapped on 2 lines `Foo bar` will look different to `Foo \nbar`.
+    /// So right-aligned wrapped on 2 lines `Foo bar` will look different to `Foo \nbar`.
     #[test]
     fn include_spaces_in_layout_width_preceeded_hard_break() {
         // should wrap due to width bound
@@ -1019,6 +1019,42 @@ mod layout_test {
             "explicit newline `F` ({}) should be 1 space to the left of no-newline `F` ({})",
             newline_f.glyph.position.x,
             no_newline_f.glyph.position.x,
+        );
+    }
+
+    /// #130 - Respect trailing whitespace in words if directly preceeding end-of-glyphs.
+    /// So right-aligned `Foo ` will look different to `Foo`.
+    #[test]
+    fn include_spaces_in_layout_width_preceeded_end() {
+        let glyphs_no_newline = Layout::default()
+            .h_align(HorizontalAlign::Right)
+            .calculate_glyphs(
+                &*FONT_MAP,
+                &<_>::default(),
+                &[SectionText {
+                    text: "Foo",
+                    ..<_>::default()
+                }],
+            );
+
+        let glyphs_space = Layout::default()
+            .h_align(HorizontalAlign::Right)
+            .calculate_glyphs(
+                &*FONT_MAP,
+                &<_>::default(),
+                &[SectionText {
+                    text: "Foo   ",
+                    ..<_>::default()
+                }],
+            );
+
+        let space_f = &glyphs_space[0];
+        let no_space_f = &glyphs_no_newline[0];
+        assert!(
+            space_f.glyph.position.x < no_space_f.glyph.position.x,
+            "with-space `F` ({}) should be 3 spaces to the left of no-space `F` ({})",
+            space_f.glyph.position.x,
+            no_space_f.glyph.position.x,
         );
     }
 }

--- a/layout/src/characters.rs
+++ b/layout/src/characters.rs
@@ -65,7 +65,9 @@ where
 
     /// Wraps into a `Words` iterator.
     pub(crate) fn words(self) -> Words<'a, 'b, L, F, S> {
-        Words { characters: self }
+        Words {
+            characters: self.peekable(),
+        }
     }
 }
 

--- a/layout/src/words.rs
+++ b/layout/src/words.rs
@@ -5,7 +5,7 @@ use crate::{
     SectionGlyph, SectionText,
 };
 use ab_glyph::*;
-use std::iter::{FusedIterator, Iterator};
+use std::iter::{FusedIterator, Iterator, Peekable};
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct VMetrics {
@@ -62,7 +62,7 @@ where
     F: Font,
     S: Iterator<Item = SectionText<'a>>,
 {
-    pub(crate) characters: Characters<'a, 'b, L, F, S>,
+    pub(crate) characters: Peekable<Characters<'a, 'b, L, F, S>>,
 }
 
 impl<'a, 'b, L, F, S> Words<'a, 'b, L, F, S>
@@ -137,7 +137,10 @@ where
 
             if line_break.is_some() {
                 if let Some(LineBreak::Hard(..)) = line_break {
-                    hard_break = true
+                    hard_break = true;
+                } else if self.characters.peek().is_none() {
+                    // simulate hard-break at end of all sections
+                    hard_break = true;
                 }
                 break;
             }


### PR DESCRIPTION
In addition to #131 simulate a hard-break at the end of all glyph sections so that behaves the same way with trailing space.