### PR TITLE
Use line_gap as top padding

### DIFF
--- a/layout/CHANGELOG.md
+++ b/layout/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+* Use font line_gap as top-padding for layouts to address issues with glyphs taller than the font ascent.
+
 # 0.2.3
 * Default layouts: Keep word trailing space width if ending in a hard break or end of all glyphs _e.g. `"Foo  \n"`_ _(This particularly changes the layout of right & centre aligned text ending in spaces)_. 
 

--- a/layout/src/builtin.rs
+++ b/layout/src/builtin.rs
@@ -723,11 +723,12 @@ mod layout_test {
             ],
         );
 
+        let sfont = A_FONT.as_scaled(40.0);
         for g in glyphs {
             println!("{:?}", (g.glyph.scale, g.glyph.position));
             // all glyphs should have the same ascent drawing position
             let y_pos = g.glyph.position.y;
-            assert_relative_eq!(y_pos, A_FONT.as_scaled(40.0).ascent());
+            assert_relative_eq!(y_pos, sfont.ascent() + sfont.line_gap());
         }
     }
 

--- a/layout/src/lines.rs
+++ b/layout/src/lines.rs
@@ -28,6 +28,10 @@ impl Line {
             return Vec::new();
         }
 
+        // use line_gap as top-padding for all lines
+        // fixes issues with glyphs taller than the ascent
+        let screen_y = screen_y + self.max_v_metrics.line_gap;
+
         // implement v-aligns when they're are supported
         let screen_left = match h_align {
             HorizontalAlign::Left => point(screen_x, screen_y),


### PR DESCRIPTION
Use line_gap to top-pad layouts to address potential clipping.

Fixes #143

