### PR TITLE
Remove implicit frame cleanup

### DIFF
--- a/gfx-glyph/src/lib.rs
+++ b/gfx-glyph/src/lib.rs
@@ -160,7 +160,7 @@ pub fn default_transform<D: IntoDimensions>(d: D) -> [[f32; 4]; 4] {
 /// used for actual drawing.
 ///
 /// The cache for a section will be **cleared** after a
-/// [`.use_queue().draw(..)`](struct.DrawBuilder.html#method.draw) call when that section has not been used since
+/// [`.cleanup_frame()`](struct.DrawBuilder.html#method.draw) call when that section has not been used since
 /// the previous draw call.
 pub struct GlyphBrush<R: gfx::Resources, GF: gfx::Factory<R>, F = FontArc, H = DefaultSectionHasher>
 {
@@ -262,8 +262,6 @@ where
 
     /// Returns a [`DrawBuilder`](struct.DrawBuilder.html) allowing the queued glyphs to be drawn.
     ///
-    /// Drawing will trim the cache, see [caching behaviour](#caching-behaviour).
-    ///
     /// # Example
     ///
     /// ```no_run
@@ -346,6 +344,12 @@ where
         S: Into<Cow<'a, Section<'a>>>,
     {
         self.glyph_brush.keep_cached(section)
+    }
+
+    /// Trims the cache. Should be called once per frame.
+    #[inline]
+    pub fn cleanup_frame<S>(&mut self) {
+        self.glyph_brush.cleanup_frame();
     }
 
     /// Returns the available fonts.

--- a/glyph-brush/examples/draw_cache_guts.rs
+++ b/glyph-brush/examples/draw_cache_guts.rs
@@ -262,6 +262,8 @@ fn main() -> Res<()> {
 
                 window_ctx.swap_buffers().unwrap();
 
+                glyph_brush.cleanup_frame();
+
                 if let Some(rate) = loop_helper.report_rate() {
                     fps = rate;
                 }

--- a/glyph-brush/examples/opengl.rs
+++ b/glyph-brush/examples/opengl.rs
@@ -251,6 +251,8 @@ fn main() -> Res<()> {
 
                 window_ctx.swap_buffers().unwrap();
 
+                glyph_brush.cleanup_frame();
+
                 if let Some(rate) = loop_helper.report_rate() {
                     window_ctx
                         .window()

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -39,7 +39,7 @@ type SectionHash = u64;
 /// used for actual drawing.
 ///
 /// The cache for a section will be **cleared** after a
-/// [`GlyphBrush::process_queued`] call when that section has not been used
+/// [`GlyphBrush::cleanup_frame()`] call when that section has not been used
 /// since the previous call.
 ///
 /// # Texture caching behaviour
@@ -339,7 +339,8 @@ where
         self.texture_cache.dimensions()
     }
 
-    fn cleanup_frame(&mut self) {
+    /// Trims the cache. Should be called once per frame.
+    pub fn cleanup_frame(&mut self) {
         if self.cache_glyph_positioning {
             // clear section_buffer & trim calculate_glyph_cache to active sections
             let active = mem::take(&mut self.keep_in_cache);
@@ -421,8 +422,6 @@ where
     /// * `to_vertex` maps a single glyph's `GlyphVertex` data into a generic vertex type. The
     ///   mapped vertices are returned in an `Ok(BrushAction::Draw(vertices))` result.
     ///   It's recommended to use a single vertex per glyph quad for best performance.
-    ///
-    /// Trims the cache, see [caching behaviour](#caching-behaviour).
     ///
     /// ```no_run
     /// # use glyph_brush::{ab_glyph::*, *};
@@ -527,8 +526,6 @@ where
         } else {
             BrushAction::ReDraw
         };
-
-        self.cleanup_frame();
         Ok(result)
     }
 


### PR DESCRIPTION
Currently glyph_brush assumes that all text to be rendered in a frame is queued and then drawn at once with a single draw call. The different renderer implementations provide these draw methods, which call `GlyphBrush::process_queued()` under the hood, which currently implicitly maintains the cache. Using one draw call for all text in a single frame may be unfeasible, e.g. rendering text with transparency and proper z-ordering or using multiple scissoring regions, which causes many cache cleanups and misses. By allowing the user to manually control the cache cleanup, that issue can be avoid.

Resolves #128.