### PR TITLE
Feat/emoji_support

### DIFF
--- a/draw-cache/Cargo.toml
+++ b/draw-cache/Cargo.toml
@@ -10,9 +10,10 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-ab_glyph = "0.2.2"
+ab_glyph = "0.2.19"
 linked-hash-map = "0.5.4"
 rustc-hash = "1"
+image = "0.24.5"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 crossbeam-channel = "0.5"

--- a/draw-cache/src/lib.rs
+++ b/draw-cache/src/lib.rs
@@ -1136,6 +1136,9 @@ impl GlyphKind for ImageGlyph {
         let image = font.glyph_raster_image(glyph.id, glyph.scale.x.max(glyph.scale.y) as _)?;
         let decoded_image = image::load_from_memory(image.data).ok()?;
 
+        let h_advance = font.as_scaled(glyph.scale).h_advance(glyph.id);
+        let v_advance = font.as_scaled(glyph.scale).v_advance(glyph.id);
+
         let mut px_bounds = ImageGlyph::cal_img_px_bounds(
             PxScaleFactor {
                 horizontal: h_advance / image.scale,

--- a/glyph-brush/src/glyph_brush/builder.rs
+++ b/glyph-brush/src/glyph_brush/builder.rs
@@ -19,7 +19,8 @@ pub struct GlyphBrushBuilder<F = FontArc, H = DefaultSectionHasher> {
     pub cache_glyph_positioning: bool,
     pub cache_redraws: bool,
     pub section_hasher: H,
-    pub draw_cache_builder: DrawCacheBuilder,
+    pub outline_draw_cache_builder: DrawCacheBuilder<OutlinedGlyph>,
+    pub emoji_draw_cache_builder: DrawCacheBuilder<ImageGlyph>,
 }
 
 impl GlyphBrushBuilder<()> {
@@ -41,7 +42,12 @@ impl GlyphBrushBuilder<()> {
             cache_glyph_positioning: true,
             cache_redraws: true,
             section_hasher: DefaultSectionHasher::default(),
-            draw_cache_builder: DrawCache::builder()
+            outline_draw_cache_builder: DrawCache::builder()
+                .dimensions(256, 256)
+                .scale_tolerance(0.5)
+                .position_tolerance(0.1)
+                .align_4x4(false),
+            emoji_draw_cache_builder: DrawCache::builder()
                 .dimensions(256, 256)
                 .scale_tolerance(0.5)
                 .position_tolerance(0.1)
@@ -88,7 +94,8 @@ impl<F, H> GlyphBrushBuilder<F, H> {
             cache_glyph_positioning: self.cache_glyph_positioning,
             cache_redraws: self.cache_redraws,
             section_hasher: self.section_hasher,
-            draw_cache_builder: self.draw_cache_builder,
+            outline_draw_cache_builder: self.outline_draw_cache_builder,
+            emoji_draw_cache_builder: self.emoji_draw_cache_builder,
         }
     }
 }
@@ -107,7 +114,8 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
     ///
     /// Defaults to `(256, 256)`
     pub fn initial_cache_size(mut self, (w, h): (u32, u32)) -> Self {
-        self.draw_cache_builder = self.draw_cache_builder.dimensions(w, h);
+        self.outline_draw_cache_builder = self.outline_draw_cache_builder.dimensions(w, h);
+        self.emoji_draw_cache_builder = self.emoji_draw_cache_builder.dimensions(w, h);
         self
     }
 
@@ -117,8 +125,13 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
     /// Defaults to `0.5`
     ///
     /// See docs for `glyph_brush_draw_cache::DrawCache`
-    pub fn draw_cache_scale_tolerance(mut self, tolerance: f32) -> Self {
-        self.draw_cache_builder = self.draw_cache_builder.scale_tolerance(tolerance);
+    pub fn outline_draw_cache_scale_tolerance(mut self, tolerance: f32) -> Self {
+        self.outline_draw_cache_builder = self.outline_draw_cache_builder.scale_tolerance(tolerance);
+        self
+    }
+
+    pub fn emoji_draw_cache_scale_tolerance(mut self, tolerance: f32) -> Self {
+        self.emoji_draw_cache_builder = self.emoji_draw_cache_builder.scale_tolerance(tolerance);
         self
     }
 
@@ -129,16 +142,25 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
     /// Defaults to `0.1`
     ///
     /// See docs for `glyph_brush_draw_cache::DrawCache`
-    pub fn draw_cache_position_tolerance(mut self, tolerance: f32) -> Self {
-        self.draw_cache_builder = self.draw_cache_builder.position_tolerance(tolerance);
+    pub fn outline_draw_cache_position_tolerance(mut self, tolerance: f32) -> Self {
+        self.outline_draw_cache_builder = self.outline_draw_cache_builder.position_tolerance(tolerance);
         self
     }
 
+    pub fn emoji_draw_cache_position_tolerance(mut self, tolerance: f32) -> Self {
+        self.emoji_draw_cache_builder = self.emoji_draw_cache_builder.position_tolerance(tolerance);
+        self
+    }
     /// When multiple CPU cores are available spread draw-cache work across all cores.
     ///
     /// Defaults to `true`.
-    pub fn multithread(mut self, multithread: bool) -> Self {
-        self.draw_cache_builder = self.draw_cache_builder.multithread(multithread);
+    pub fn outline_multithread(mut self, multithread: bool) -> Self {
+        self.outline_draw_cache_builder = self.outline_draw_cache_builder.multithread(multithread);
+        self
+    }
+
+    pub fn emoji_multithread(mut self, multithread: bool) -> Self {
+        self.emoji_draw_cache_builder = self.emoji_draw_cache_builder.multithread(multithread);
         self
     }
 
@@ -150,8 +172,13 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
     /// Defaults to `false`
     ///
     /// See docs for `glyph_brush_draw_cache::DrawCache`
-    pub fn draw_cache_align_4x4(mut self, align: bool) -> Self {
-        self.draw_cache_builder = self.draw_cache_builder.align_4x4(align);
+    pub fn outline_draw_cache_align_4x4(mut self, align: bool) -> Self {
+        self.outline_draw_cache_builder = self.outline_draw_cache_builder.align_4x4(align);
+        self
+    }
+
+    pub fn emoji_draw_cache_align_4x4(mut self, align: bool) -> Self {
+        self.emoji_draw_cache_builder = self.emoji_draw_cache_builder.align_4x4(align);
         self
     }
 
@@ -204,7 +231,8 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
             font_data: self.font_data,
             cache_glyph_positioning: self.cache_glyph_positioning,
             cache_redraws: self.cache_redraws,
-            draw_cache_builder: self.draw_cache_builder,
+            outline_draw_cache_builder: self.outline_draw_cache_builder,
+            emoji_draw_cache_builder: self.emoji_draw_cache_builder,
         }
     }
 
@@ -223,7 +251,8 @@ impl<F: Font, H: BuildHasher> GlyphBrushBuilder<F, H> {
     pub fn build<V, X>(self) -> GlyphBrush<V, X, F, H> {
         GlyphBrush {
             fonts: self.font_data,
-            texture_cache: self.draw_cache_builder.build(),
+            outline_cache: self.outline_draw_cache_builder.build(),
+            emoji_cache: self.emoji_draw_cache_builder.build(),
 
             last_draw: <_>::default(),
             section_buffer: <_>::default(),
@@ -339,8 +368,13 @@ macro_rules! delegate_glyph_brush_builder_fns {
         /// Defaults to `0.5`
         ///
         /// See docs for `glyph_brush_draw_cache::DrawCache`
-        pub fn draw_cache_scale_tolerance(mut self, tolerance: f32) -> Self {
-            self.$inner = self.$inner.draw_cache_scale_tolerance(tolerance);
+        pub fn outline_draw_cache_scale_tolerance(mut self, tolerance: f32) -> Self {
+            self.$inner = self.$inner.outline_draw_cache_scale_tolerance(tolerance);
+            self
+        }
+
+        pub fn emoji_draw_cache_scale_tolerance(mut self, tolerance: f32) -> Self {
+            self.$inner = self.$inner.emoji_draw_cache_scale_tolerance(tolerance);
             self
         }
 
@@ -351,8 +385,13 @@ macro_rules! delegate_glyph_brush_builder_fns {
         /// Defaults to `0.1`
         ///
         /// See docs for `glyph_brush_draw_cache::DrawCache`
-        pub fn draw_cache_position_tolerance(mut self, tolerance: f32) -> Self {
-            self.$inner = self.$inner.draw_cache_position_tolerance(tolerance);
+        pub fn outline_draw_cache_position_tolerance(mut self, tolerance: f32) -> Self {
+            self.$inner = self.$inner.outline_draw_cache_position_tolerance(tolerance);
+            self
+        }
+
+        pub fn emoji_draw_cache_position_tolerance(mut self, tolerance: f32) -> Self {
+            self.$inner = self.$inner.emoji_draw_cache_position_tolerance(tolerance);
             self
         }
 
@@ -364,8 +403,13 @@ macro_rules! delegate_glyph_brush_builder_fns {
         /// Defaults to `false`
         ///
         /// See docs for `glyph_brush_draw_cache::DrawCache`
-        pub fn draw_cache_align_4x4(mut self, b: bool) -> Self {
-            self.$inner = self.$inner.draw_cache_align_4x4(b);
+        pub fn outline_draw_cache_align_4x4(mut self, b: bool) -> Self {
+            self.$inner = self.$inner.outline_draw_cache_align_4x4(b);
+            self
+        }
+
+        pub fn emoji_draw_cache_align_4x4(mut self, b: bool) -> Self {
+            self.$inner = self.$inner.emoji_draw_cache_align_4x4(b);
             self
         }
 

--- a/glyph-brush/src/legacy.rs
+++ b/glyph-brush/src/legacy.rs
@@ -3,7 +3,7 @@ use ab_glyph::PxScale;
 use ordered_float::OrderedFloat;
 use std::{borrow::Cow, f32, hash::*};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SectionText<'a> {
     /// Text to render
     pub text: &'a str,
@@ -16,7 +16,7 @@ pub struct SectionText<'a> {
     /// It must be known to the `GlyphBrush` it is being used with,
     /// either `FontId::default()` or the return of
     /// [`add_font`](struct.GlyphBrushBuilder.html#method.add_font).
-    pub font_id: FontId,
+    pub fonts_id: Vec<FontId>,
 }
 
 impl Default for SectionText<'static> {
@@ -26,7 +26,7 @@ impl Default for SectionText<'static> {
             text: "",
             scale: PxScale::from(16.0),
             color: [0.0, 0.0, 0.0, 1.0],
-            font_id: <_>::default(),
+            fonts_id: Vec::default(),
         }
     }
 }
@@ -38,7 +38,7 @@ impl<'a> SectionText<'a> {
         crate::Text::new(self.text)
             .with_scale(self.scale)
             .with_color(self.color)
-            .with_font_id(self.font_id)
+            .with_fonts_id(self.fonts_id.clone())
             .with_z(z)
     }
 }
@@ -50,7 +50,7 @@ impl<'a> From<&crate::Text<'a>> for SectionText<'a> {
             text: t.text,
             scale: t.scale,
             color: t.extra.color,
-            font_id: t.font_id,
+            fonts_id: t.fonts_id.clone(),
         }
     }
 }
@@ -189,7 +189,7 @@ fn hash_section_text<H: Hasher>(state: &mut H, text: &[SectionText]) {
             text,
             scale,
             color,
-            font_id,
+            ref fonts_id,
         } = *t;
 
         let ord_floats: &[OrderedFloat<_>] = &[
@@ -201,7 +201,7 @@ fn hash_section_text<H: Hasher>(state: &mut H, text: &[SectionText]) {
             color[3].into(),
         ];
 
-        (text, font_id, ord_floats).hash(state);
+        (text, fonts_id, ord_floats).hash(state);
     }
 }
 
@@ -258,7 +258,7 @@ impl<'a> From<VariedSection<'a>> for crate::Section<'a> {
 ///     ..Section::default()
 /// };
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Section<'a> {
     /// Text to render
     pub text: &'a str,
@@ -280,7 +280,7 @@ pub struct Section<'a> {
     /// It must be known to the `GlyphBrush` it is being used with,
     /// either `FontId::default()` or the return of
     /// [`add_font`](struct.GlyphBrushBuilder.html#method.add_font).
-    pub font_id: FontId,
+    pub fonts_id: Vec<FontId>,
 }
 
 impl Default for Section<'static> {
@@ -294,7 +294,7 @@ impl Default for Section<'static> {
             color: [0.0, 0.0, 0.0, 1.0],
             z: 0.0,
             layout: Layout::default(),
-            font_id: FontId::default(),
+            fonts_id: Vec::default(),
         }
     }
 }
@@ -309,7 +309,7 @@ impl<'a> From<&Section<'a>> for VariedSection<'a> {
             bounds,
             z,
             layout,
-            font_id,
+            ref fonts_id,
         } = *s;
 
         VariedSection {
@@ -317,7 +317,7 @@ impl<'a> From<&Section<'a>> for VariedSection<'a> {
                 text,
                 scale,
                 color,
-                font_id,
+                fonts_id: fonts_id.to_vec(),
             }],
             screen_position,
             bounds,
@@ -355,7 +355,7 @@ impl<'a> From<&Section<'a>> for crate::Section<'a> {
             bounds,
             z,
             layout,
-            font_id,
+            ref fonts_id,
         } = *s;
 
         crate::Section::default()
@@ -364,7 +364,7 @@ impl<'a> From<&Section<'a>> for crate::Section<'a> {
                     .with_scale(scale)
                     .with_color(color)
                     .with_z(z)
-                    .with_font_id(font_id),
+                    .with_fonts_id(fonts_id.to_vec()),
             )
             .with_screen_position(screen_position)
             .with_bounds(bounds)
@@ -469,7 +469,7 @@ pub struct OwnedSectionText {
     /// It must be known to the `GlyphBrush` it is being used with,
     /// either `FontId::default()` or the return of
     /// [`add_font`](struct.GlyphBrushBuilder.html#method.add_font).
-    pub font_id: FontId,
+    pub fonts_id: Vec<FontId>,
 }
 
 impl Default for OwnedSectionText {
@@ -478,7 +478,7 @@ impl Default for OwnedSectionText {
             text: String::new(),
             scale: PxScale::from(16.0),
             color: [0.0, 0.0, 0.0, 1.0],
-            font_id: FontId::default(),
+            fonts_id: Vec::default(),
         }
     }
 }
@@ -489,7 +489,7 @@ impl<'a> From<&'a OwnedSectionText> for SectionText<'a> {
             text: owned.text.as_str(),
             scale: owned.scale,
             color: owned.color,
-            font_id: owned.font_id,
+            fonts_id: owned.fonts_id.clone(),
         }
     }
 }
@@ -500,7 +500,7 @@ impl From<&SectionText<'_>> for OwnedSectionText {
             text: st.text.into(),
             scale: st.scale,
             color: st.color,
-            font_id: st.font_id,
+            fonts_id: st.fonts_id.clone(),
         }
     }
 }

--- a/glyph-brush/src/lib.rs
+++ b/glyph-brush/src/lib.rs
@@ -11,19 +11,21 @@
 //! glyph_brush.queue(Section::default().add_text(Text::new("Hello glyph_brush")));
 //! glyph_brush.queue(some_other_section);
 //!
-//! # fn update_texture(_: glyph_brush::Rectangle<u32>, _: &[u8]) {}
+//! # fn update_texture(_: glyph_brush::Rectangle<u32>, _: &[K::Element]) {}
 //! # fn into_vertex(v: glyph_brush::GlyphVertex) { () }
 //! match glyph_brush.process_queued(
-//!     |rect, tex_data| update_texture(rect, tex_data),
+//!     &mut (),
+//!     |rect, outline_data, _| update_texture(rect, outline_data),
+//!     |rect, emoji_data, _| update_texture(rect, emoji_data),
 //!     |vertex_data| into_vertex(vertex_data),
 //! ) {
-//!     Ok(BrushAction::Draw(vertices)) => {
+//!     Ok(BrushAction::Draw(outline_vertices, emoji_vertices)) => {
 //!         // Draw new vertices.
 //!     }
 //!     Ok(BrushAction::ReDraw) => {
 //!         // Re-draw last frame's vertices unmodified.
 //!     }
-//!     Err(BrushError::TextureTooSmall { suggested }) => {
+//!     Err(BrushError::TextureTooSmall { types, suggested }) => {
 //!         // Enlarge texture + glyph_brush texture cache and retry.
 //!     }
 //! }

--- a/glyph-brush/src/owned_section.rs
+++ b/glyph-brush/src/owned_section.rs
@@ -96,7 +96,7 @@ pub struct OwnedText<X = Extra> {
     /// It must be known to the `GlyphBrush` it is being used with,
     /// either `FontId::default()` or the return of
     /// [`add_font`](struct.GlyphBrushBuilder.html#method.add_font).
-    pub font_id: FontId,
+    pub fonts_id: Vec<FontId>,
     // Extra stuff for vertex generation.
     pub extra: X,
 }
@@ -115,8 +115,12 @@ impl<X> OwnedText<X> {
     }
 
     #[inline]
-    pub fn with_font_id<F: Into<FontId>>(mut self, font_id: F) -> Self {
-        self.font_id = font_id.into();
+    pub fn with_fonts_id<F: Into<FontId>>(mut self, fonts_id: Vec<F>) -> Self {
+        let mut fonts = vec![];
+        for id in fonts_id {
+            fonts.push(id.into());
+        }
+        self.fonts_id = fonts;
         self
     }
 
@@ -125,7 +129,7 @@ impl<X> OwnedText<X> {
         OwnedText {
             text: self.text,
             scale: self.scale,
-            font_id: self.font_id,
+            fonts_id: self.fonts_id,
             extra,
         }
     }
@@ -156,7 +160,7 @@ impl<X: Default> Default for OwnedText<X> {
         Self {
             text: String::new(),
             scale: PxScale::from(16.0),
-            font_id: <_>::default(),
+            fonts_id: Vec::default(),
             extra: <_>::default(),
         }
     }
@@ -168,7 +172,7 @@ impl<'a, X: Clone> From<&'a OwnedText<X>> for Text<'a, X> {
         Self {
             text: owned.text.as_str(),
             scale: owned.scale,
-            font_id: owned.font_id,
+            fonts_id: owned.fonts_id.clone(),
             extra: owned.extra.clone(),
         }
     }
@@ -180,7 +184,7 @@ impl<X: Clone> From<&Text<'_, X>> for OwnedText<X> {
         Self {
             text: s.text.into(),
             scale: s.scale,
-            font_id: s.font_id,
+            fonts_id: s.fonts_id.clone(),
             extra: s.extra.clone(),
         }
     }

--- a/layout/src/section.rs
+++ b/layout/src/section.rs
@@ -21,7 +21,7 @@ impl Default for SectionGeometry {
 }
 
 /// Text to layout together using a font & scale.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct SectionText<'a> {
     /// Text to render
     pub text: &'a str,
@@ -31,7 +31,7 @@ pub struct SectionText<'a> {
     ///
     /// It must be a valid id in the `FontMap` used for layout calls.
     /// The default `FontId(0)` should always be valid.
-    pub font_id: FontId,
+    pub fonts_id: Vec<FontId>,
 }
 
 impl Default for SectionText<'static> {
@@ -40,7 +40,7 @@ impl Default for SectionText<'static> {
         Self {
             text: "",
             scale: PxScale::from(16.0),
-            font_id: FontId::default(),
+            fonts_id: Vec::default(),
         }
     }
 }
@@ -52,14 +52,14 @@ pub trait ToSectionText {
 impl ToSectionText for SectionText<'_> {
     #[inline]
     fn to_section_text(&self) -> SectionText<'_> {
-        *self
+        self.clone()
     }
 }
 
 impl ToSectionText for &SectionText<'_> {
     #[inline]
     fn to_section_text(&self) -> SectionText<'_> {
-        **self
+        (*self).clone()
     }
 }
 


### PR DESCRIPTION
Support the Rendering of emoji.
1. Maintain two mapping textures at the same time, one for the normal text and one for the emoji. Add an `emoji_cache` in `GlyphBrush`, and upload the textures separately. The data's type in `outline_cache` is u8, and in `emoji_cache` is u32.
2. In order to recognize emojis in a string, the `font_id` in `Text` is changed to a vector type, thus supporting both normal fonts and emoji fonts.

Todo: 
1. I don't have a good idea about How should emoji align with baseline, so align the lower edge of the emoji's bounds with the baseline.
2. Codepoints recognition is not yet supported, such like ZWJ.
