### PR TITLE
More flexible `X`/"extra" type handling

### DIFF
--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased (v0.7.7)
+* Allow `Text::new` to work with any `X` type. **This may break usage**, however it will hopefully be non-breaking in practice as the compiler should always be able to infer this.
+* Add `Section::builder` for more flexible `X`/"extra" type usage than `Section::default`.
+* Add more flexible `X` type usage to `GlyphBrush::keep_cached`.
 * Update `GlyphCruncher::glyphs`, `GlyphCruncher::glyph_bounds` docs.
 
 # v0.7.6

--- a/glyph-brush/CHANGELOG.md
+++ b/glyph-brush/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Allow `Text::new` to work with any `X` type. **This may break usage**, however it will hopefully be non-breaking in practice as the compiler should always be able to infer this.
 * Add `Section::builder` for more flexible `X`/"extra" type usage than `Section::default`.
 * Add more flexible `X` type usage to `GlyphBrush::keep_cached`.
+* Add `Section::from(text)` & `Section::from(vec![text])` conversions.
 * Update `GlyphCruncher::glyphs`, `GlyphCruncher::glyph_bounds` docs.
 
 # v0.7.6

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -831,8 +831,7 @@ mod glyph_brush_test {
         let font_b = FontRef::try_from_slice(include_bytes!("../../fonts/Exo2-Light.otf")).unwrap();
         let unqueued_glyph = font_a.glyph_id('c').with_scale(50.0);
 
-        let mut brush: GlyphBrush<_, (), _> =
-            GlyphBrushBuilder::using_fonts(vec![font_a, font_b]).build();
+        let mut brush = GlyphBrushBuilder::using_fonts(vec![font_a, font_b]).build();
 
         let section = Section::default()
             .add_text(Text::new("a "))

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -831,7 +831,8 @@ mod glyph_brush_test {
         let font_b = FontRef::try_from_slice(include_bytes!("../../fonts/Exo2-Light.otf")).unwrap();
         let unqueued_glyph = font_a.glyph_id('c').with_scale(50.0);
 
-        let mut brush = GlyphBrushBuilder::using_fonts(vec![font_a, font_b]).build();
+        let mut brush: GlyphBrush<_, (), _> =
+            GlyphBrushBuilder::using_fonts(vec![font_a, font_b]).build();
 
         let section = Section::default()
             .add_text(Text::new("a "))

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -371,8 +371,9 @@ where
     /// Should not generally be necessary, see [caching behaviour](#caching-behaviour).
     pub fn keep_cached_custom_layout<'a, S, G>(&mut self, section: S, custom_layout: &G)
     where
-        S: Into<Cow<'a, Section<'a>>>,
+        S: Into<Cow<'a, Section<'a, X>>>,
         G: GlyphPositioner,
+        X: 'a,
     {
         if !self.cache_glyph_positioning {
             return;
@@ -393,7 +394,8 @@ where
     /// Should not generally be necessary, see [caching behaviour](#caching-behaviour).
     pub fn keep_cached<'a, S>(&mut self, section: S)
     where
-        S: Into<Cow<'a, Section<'a>>>,
+        S: Into<Cow<'a, Section<'a, X>>>,
+        X: 'a,
     {
         let section = section.into();
         let layout = section.layout;

--- a/glyph-brush/src/glyph_calculator.rs
+++ b/glyph-brush/src/glyph_calculator.rs
@@ -106,7 +106,7 @@ pub trait GlyphCruncher<F: Font = FontArc, X: Clone = Extra> {
 /// use glyph_brush::{ab_glyph::FontArc, GlyphCalculatorBuilder, GlyphCruncher, Section, Text};
 ///
 /// let dejavu = FontArc::try_from_slice(include_bytes!("../../fonts/DejaVuSans.ttf")).unwrap();
-/// let glyphs = GlyphCalculatorBuilder::using_font(dejavu).build();
+/// let glyphs = GlyphCalculatorBuilder::using_font(dejavu).build::<()>();
 ///
 /// let section = Section::default().add_text(Text::new("Hello glyph_brush"));
 ///
@@ -354,7 +354,7 @@ impl<F: Font, H: BuildHasher> GlyphCalculatorBuilder<F, H> {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct GlyphedSection<X = Extra> {
+pub(crate) struct GlyphedSection<X> {
     pub bounds: Rect,
     pub glyphs: Vec<SectionGlyph>,
     pub extra: Vec<X>,
@@ -383,7 +383,7 @@ mod test {
 
     #[test]
     fn glyph_bounds() {
-        let glyphs = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build();
+        let glyphs = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build::<Extra>();
         let mut glyphs = glyphs.cache_scope();
 
         let scale = PxScale::from(16.0);
@@ -411,7 +411,7 @@ mod test {
 
     #[test]
     fn glyph_bounds_respect_layout_bounds() {
-        let glyphs = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build();
+        let glyphs = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build::<Extra>();
         let mut glyphs = glyphs.cache_scope();
 
         let section = Section::default()
@@ -481,7 +481,7 @@ mod test {
     /// Issue #87
     #[test]
     fn glyph_bound_section_bound_consistency() {
-        let calc = GlyphCalculatorBuilder::using_font(OPEN_SANS_LIGHT.clone()).build();
+        let calc = GlyphCalculatorBuilder::using_font(OPEN_SANS_LIGHT.clone()).build::<()>();
         let mut calc = calc.cache_scope();
 
         let section =
@@ -506,7 +506,7 @@ mod test {
     /// Issue #87
     #[test]
     fn glyph_bound_section_bound_consistency_trailing_space() {
-        let calc = GlyphCalculatorBuilder::using_font(OPEN_SANS_LIGHT.clone()).build();
+        let calc = GlyphCalculatorBuilder::using_font(OPEN_SANS_LIGHT.clone()).build::<()>();
         let mut calc = calc.cache_scope();
 
         let section =
@@ -532,7 +532,7 @@ mod test {
     /// error between the calculated glyph_bounds bounds & those used during layout.
     #[test]
     fn glyph_bound_section_bound_consistency_floating_point() {
-        let calc = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build();
+        let calc = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build::<()>();
         let mut calc = calc.cache_scope();
 
         let section = Section::default().add_text(Text::new("Eins Zwei Drei Vier Funf"));

--- a/glyph-brush/src/glyph_calculator.rs
+++ b/glyph-brush/src/glyph_calculator.rs
@@ -106,7 +106,7 @@ pub trait GlyphCruncher<F: Font = FontArc, X: Clone = Extra> {
 /// use glyph_brush::{ab_glyph::FontArc, GlyphCalculatorBuilder, GlyphCruncher, Section, Text};
 ///
 /// let dejavu = FontArc::try_from_slice(include_bytes!("../../fonts/DejaVuSans.ttf")).unwrap();
-/// let glyphs = GlyphCalculatorBuilder::using_font(dejavu).build::<()>();
+/// let glyphs = GlyphCalculatorBuilder::using_font(dejavu).build();
 ///
 /// let section = Section::default().add_text(Text::new("Hello glyph_brush"));
 ///
@@ -383,7 +383,7 @@ mod test {
 
     #[test]
     fn glyph_bounds() {
-        let glyphs = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build::<Extra>();
+        let glyphs = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build();
         let mut glyphs = glyphs.cache_scope();
 
         let scale = PxScale::from(16.0);
@@ -411,7 +411,7 @@ mod test {
 
     #[test]
     fn glyph_bounds_respect_layout_bounds() {
-        let glyphs = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build::<Extra>();
+        let glyphs = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build();
         let mut glyphs = glyphs.cache_scope();
 
         let section = Section::default()
@@ -481,7 +481,7 @@ mod test {
     /// Issue #87
     #[test]
     fn glyph_bound_section_bound_consistency() {
-        let calc = GlyphCalculatorBuilder::using_font(OPEN_SANS_LIGHT.clone()).build::<()>();
+        let calc = GlyphCalculatorBuilder::using_font(OPEN_SANS_LIGHT.clone()).build();
         let mut calc = calc.cache_scope();
 
         let section =
@@ -506,7 +506,7 @@ mod test {
     /// Issue #87
     #[test]
     fn glyph_bound_section_bound_consistency_trailing_space() {
-        let calc = GlyphCalculatorBuilder::using_font(OPEN_SANS_LIGHT.clone()).build::<()>();
+        let calc = GlyphCalculatorBuilder::using_font(OPEN_SANS_LIGHT.clone()).build();
         let mut calc = calc.cache_scope();
 
         let section =
@@ -532,7 +532,7 @@ mod test {
     /// error between the calculated glyph_bounds bounds & those used during layout.
     #[test]
     fn glyph_bound_section_bound_consistency_floating_point() {
-        let calc = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build::<()>();
+        let calc = GlyphCalculatorBuilder::using_font(MONO_FONT.clone()).build();
         let mut calc = calc.cache_scope();
 
         let section = Section::default().add_text(Text::new("Eins Zwei Drei Vier Funf"));

--- a/glyph-brush/src/legacy.rs
+++ b/glyph-brush/src/legacy.rs
@@ -229,7 +229,7 @@ impl From<&VariedSection<'_>> for SectionGeometry {
 impl<'a> From<&VariedSection<'a>> for crate::Section<'a> {
     #[inline]
     fn from(s: &VariedSection<'a>) -> Self {
-        crate::Section::default()
+        crate::Section::<Extra>::default()
             .with_layout(s.layout)
             .with_bounds(s.bounds)
             .with_screen_position(s.screen_position)

--- a/glyph-brush/src/legacy.rs
+++ b/glyph-brush/src/legacy.rs
@@ -229,7 +229,7 @@ impl From<&VariedSection<'_>> for SectionGeometry {
 impl<'a> From<&VariedSection<'a>> for crate::Section<'a> {
     #[inline]
     fn from(s: &VariedSection<'a>) -> Self {
-        crate::Section::<Extra>::default()
+        crate::Section::builder()
             .with_layout(s.layout)
             .with_bounds(s.bounds)
             .with_screen_position(s.screen_position)

--- a/glyph-brush/src/section.rs
+++ b/glyph-brush/src/section.rs
@@ -59,9 +59,24 @@ impl<'a, X> Section<'a, X> {
 }
 
 impl Section<'_, ()> {
+    /// Return a `SectionBuilder` to fluently build up a `Section`.
     #[inline]
     pub fn builder() -> SectionBuilder {
         <_>::default()
+    }
+}
+
+impl<'a, X> From<Text<'a, X>> for Section<'a, X> {
+    #[inline]
+    fn from(text: Text<'a, X>) -> Self {
+        Section::builder().add_text(text)
+    }
+}
+
+impl<'a, X> From<Vec<Text<'a, X>>> for Section<'a, X> {
+    #[inline]
+    fn from(text: Vec<Text<'a, X>>) -> Self {
+        Section::builder().with_text(text)
     }
 }
 

--- a/glyph-brush/src/section.rs
+++ b/glyph-brush/src/section.rs
@@ -40,7 +40,7 @@ impl<X: Clone> Section<'_, X> {
     }
 }
 
-impl Default for Section<'static, Extra> {
+impl<X> Default for Section<'static, X> {
     #[inline]
     fn default() -> Self {
         Section::new()
@@ -196,12 +196,14 @@ impl<'a, X> Text<'a, X> {
     }
 }
 
-impl<'a> Text<'a, Extra> {
+impl<'a, X: Default> Text<'a, X> {
     #[inline]
     pub fn new(text: &'a str) -> Self {
         Text::default().with_text(text)
     }
+}
 
+impl<'a> Text<'a, Extra> {
     #[inline]
     pub fn with_color<C: Into<Color>>(mut self, color: C) -> Self {
         self.extra.color = color.into();

--- a/glyph-brush/src/section.rs
+++ b/glyph-brush/src/section.rs
@@ -1,7 +1,10 @@
+mod builder;
+
 use super::{owned_section::*, *};
 use ordered_float::OrderedFloat;
 use std::{borrow::Cow, f32, hash::*};
 
+pub use builder::SectionBuilder;
 pub type Color = [f32; 4];
 
 /// An object that contains all the info to render a varied section of text. That is one including
@@ -40,7 +43,8 @@ impl<X: Clone> Section<'_, X> {
     }
 }
 
-impl<X> Default for Section<'static, X> {
+impl Default for Section<'static, Extra> {
+    /// Note this only works for `X=Extra` for more flexible use see [`Section::builder`].
     #[inline]
     fn default() -> Self {
         Section::new()
@@ -50,12 +54,14 @@ impl<X> Default for Section<'static, X> {
 impl<'a, X> Section<'a, X> {
     #[inline]
     pub fn new() -> Self {
-        Self {
-            screen_position: (0.0, 0.0),
-            bounds: (f32::INFINITY, f32::INFINITY),
-            layout: Layout::default(),
-            text: vec![],
-        }
+        Section::builder().with_text(vec![])
+    }
+}
+
+impl Section<'_, ()> {
+    #[inline]
+    pub fn builder() -> SectionBuilder {
+        <_>::default()
     }
 }
 

--- a/glyph-brush/src/section/builder.rs
+++ b/glyph-brush/src/section/builder.rs
@@ -1,0 +1,59 @@
+use crate::{Section, Text};
+use glyph_brush_layout::{BuiltInLineBreaker, Layout};
+
+/// [`Section`] builder.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct SectionBuilder {
+    /// Position on screen to render text, in pixels from top-left. Defaults to (0, 0).
+    pub screen_position: (f32, f32),
+    /// Max (width, height) bounds, in pixels from top-left. Defaults to unbounded.
+    pub bounds: (f32, f32),
+    /// Built in layout, can be overridden with custom layout logic
+    /// see [`queue_custom_layout`](struct.GlyphBrush.html#method.queue_custom_layout)
+    pub layout: Layout<BuiltInLineBreaker>,
+}
+
+impl Default for SectionBuilder {
+    fn default() -> Self {
+        Self {
+            screen_position: (0.0, 0.0),
+            bounds: (f32::INFINITY, f32::INFINITY),
+            layout: Layout::default(),
+        }
+    }
+}
+
+impl SectionBuilder {
+    #[inline]
+    pub fn with_screen_position<P: Into<(f32, f32)>>(mut self, position: P) -> Self {
+        self.screen_position = position.into();
+        self
+    }
+
+    #[inline]
+    pub fn with_bounds<P: Into<(f32, f32)>>(mut self, bounds: P) -> Self {
+        self.bounds = bounds.into();
+        self
+    }
+
+    #[inline]
+    pub fn with_layout<L: Into<Layout<BuiltInLineBreaker>>>(mut self, layout: L) -> Self {
+        self.layout = layout.into();
+        self
+    }
+
+    #[inline]
+    pub fn add_text<X>(self, text: Text<'_, X>) -> Section<'_, X> {
+        self.with_text(vec![text])
+    }
+
+    #[inline]
+    pub fn with_text<X>(self, text: Vec<Text<'_, X>>) -> Section<'_, X> {
+        Section {
+            text,
+            screen_position: self.screen_position,
+            bounds: self.bounds,
+            layout: self.layout,
+        }
+    }
+}

--- a/glyph-brush/src/section/builder.rs
+++ b/glyph-brush/src/section/builder.rs
@@ -2,6 +2,8 @@ use crate::{Section, Text};
 use glyph_brush_layout::{BuiltInLineBreaker, Layout};
 
 /// [`Section`] builder.
+///
+/// Usage can avoid generic `X` type issues as it's not mentioned until text is involved.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SectionBuilder {
     /// Position on screen to render text, in pixels from top-left. Defaults to (0, 0).


### PR DESCRIPTION
This is a less breaking version of #162. Mainly rolling back the `Section::default` changes and adding `Section::builder` to help when using a custom `X`. This avoids the breakage that the `Section::default` change would have caused.

It's still a _little_ breaking with the `Text::new` changes. However, I'm willing to try releasing that as a non-breaking bump as I suspect this won't break usage in the wild.

Closes #162 