### PR TITLE
Add clarification of coordinates for `Rectangle` fields

### DIFF
--- a/draw-cache/src/geometry.rs
+++ b/draw-cache/src/geometry.rs
@@ -1,6 +1,7 @@
 use core::ops;
 
 /// A rectangle, with top-left corner at min, and bottom-right corner at max.
+/// Both field are in `[offset from left, offset from top]` format.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Rectangle<N> {
     pub min: [N; 2],


### PR DESCRIPTION
I spent almost a day trying to figure out why my texture map is so strange because I assumed that fields store coordinates in opposite order (_y_ than _x_) because of wording `top-left` and `bottom-right`.