### PR TITLE
Omit whitespace line trailing glyphs

### DIFF
--- a/layout/CHANGELOG.md
+++ b/layout/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Unreleased (0.2.4)
+* Default layouts: Whitespace `SectionGlyph`s ignored for purposes of positioning are now also omitted entirely
+  from `GlyphPositioner::calculate_glyphs`.
 * Fix `SectionText::scale` docs.
 
 # 0.2.3

--- a/layout/src/lines.rs
+++ b/layout/src/lines.rs
@@ -17,6 +17,17 @@ impl Line {
         self.max_v_metrics.ascent - self.max_v_metrics.descent + self.max_v_metrics.line_gap
     }
 
+    /// Remove glyphs past the `rightmost` point, ie whitespace.
+    pub(crate) fn remove_trailing_glyphs(&mut self) {
+        for idx in (0..self.glyphs.len()).rev() {
+            if self.glyphs[idx].glyph.position.x >= self.rightmost {
+                self.glyphs.pop();
+            } else {
+                break;
+            }
+        }
+    }
+
     /// Returns line glyphs positioned on the screen and aligned.
     pub fn aligned_on_screen(
         mut self,
@@ -111,6 +122,8 @@ where
 
             // only if `progressed` means the first word is allowed to overlap the bounds
             if !word_in_bounds && progressed {
+                // remove trailing whitespace oob glyphs
+                line.remove_trailing_glyphs();
                 break;
             }
 


### PR DESCRIPTION
Default layouts: Whitespace `SectionGlyph`s ignored for purposes of positioning are now also omitted entirely from `GlyphPositioner::calculate_glyphs`.

So right-aligned `"foo   b r"` with ~3 char width bound, previously
```
foo|___
b_r|
```
Now
```
foo|
b_r|
```

## Issues
This change may cause issues. Take a text editor use case. Previously the layout provide a position for all spaces, this could be used to render the cursor (like in https://github.com/alexheretic/glyph-brush/issues/130#issuecomment-781477924). By omitting the glyphs this would be much more painful. Not being able to reliably have these whitespace chars as glyphs could be an unwelcome change here.