### PR TITLE
Fix typos

### DIFF
--- a/draw-cache/src/lib.rs
+++ b/draw-cache/src/lib.rs
@@ -145,7 +145,7 @@ struct GlyphTexInfo {
     tex_coords: Rectangle<u32>,
     /// Used to calculate the bounds/texture pixel location for a similar glyph.
     ///
-    /// Each ordinate is calculated: `(bounds_ord - positon_ord) / g.scale`
+    /// Each ordinate is calculated: `(bounds_ord - position_ord) / g.scale`
     bounds_minus_position_over_scale: Rect,
 }
 
@@ -990,7 +990,7 @@ impl DrawCache {
     /// glyph that is deemed close enough to the requested glyph as specified by
     /// the cache tolerance parameters.
     ///
-    /// A sucessful result is `Some` if the glyph is not an empty glyph (no
+    /// A successful result is `Some` if the glyph is not an empty glyph (no
     /// shape, and thus no rect to return).
     ///
     /// Ensure that `font_id` matches the `font_id` that was passed to

--- a/gfx-glyph/examples/varied.rs
+++ b/gfx-glyph/examples/varied.rs
@@ -153,7 +153,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 },
                             },
                             Text {
-                                text: "Eu facilisi maluisset eos.",
+                                text: "Eu facilities maluisset eos.",
                                 scale: PxScale::from(55.0),
                                 font_id: sans_font,
                                 extra: Extra {

--- a/gfx-glyph/examples/varied.rs
+++ b/gfx-glyph/examples/varied.rs
@@ -153,7 +153,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 },
                             },
                             Text {
-                                text: "Eu facilities maluisset eos.",
+                                text: "Eu facilisi maluisset eos.",
                                 scale: PxScale::from(55.0),
                                 font_id: sans_font,
                                 extra: Extra {

--- a/gfx-glyph/src/lib.rs
+++ b/gfx-glyph/src/lib.rs
@@ -101,7 +101,7 @@ pub fn default_transform<D: IntoDimensions>(d: D) -> [[f32; 4]; 4] {
     ]
 }
 
-/// Object allowing glyph drawing, containing cache state. Manages glyph positioning cacheing,
+/// Object allowing glyph drawing, containing cache state. Manages glyph positioning caching,
 /// glyph draw caching & efficient GPU texture cache updating and re-sizing on demand.
 ///
 /// Build using a [`GlyphBrushBuilder`](struct.GlyphBrushBuilder.html).

--- a/glyph-brush/src/glyph_brush.rs
+++ b/glyph-brush/src/glyph_brush.rs
@@ -15,7 +15,7 @@ use std::{
 /// A hash of `Section` data
 type SectionHash = u64;
 
-/// Object allowing glyph drawing, containing cache state. Manages glyph positioning cacheing,
+/// Object allowing glyph drawing, containing cache state. Manages glyph positioning caching,
 /// glyph draw caching & efficient GPU texture cache updating.
 ///
 /// Build using a [`GlyphBrushBuilder`].
@@ -61,11 +61,11 @@ pub struct GlyphBrush<V, X = Extra, F = FontArc, H = DefaultSectionHasher> {
     last_frame_seq_id_sections: Vec<SectionHashDetail>,
     frame_seq_id_sections: Vec<SectionHashDetail>,
 
-    // buffer of section-layout hashs (that must exist in the calculate_glyph_cache)
+    // buffer of section-layout hashes (that must exist in the calculate_glyph_cache)
     // to be used on the next `process_queued` call
     section_buffer: Vec<SectionHash>,
 
-    // Set of section hashs to keep in the glyph cache this frame even if they haven't been drawn
+    // Set of section hashes to keep in the glyph cache this frame even if they haven't been drawn
     keep_in_cache: FxHashSet<SectionHash>,
 
     // config

--- a/layout/src/builtin.rs
+++ b/layout/src/builtin.rs
@@ -931,8 +931,8 @@ mod layout_test {
         );
     }
 
-    /// Chinese sentance squeezed into a vertical pipe meaning each character is on
-    /// a seperate line.
+    /// Chinese sentence squeezed into a vertical pipe meaning each character is on
+    /// a separate line.
     #[test]
     fn wrap_word_chinese() {
         let glyphs = Layout::default().calculate_glyphs(
@@ -964,10 +964,10 @@ mod layout_test {
         assert_eq!(y_positions.len(), 7, "{y_positions:?}");
     }
 
-    /// #130 - Respect trailing whitespace in words if directly preceeding a hard break.
+    /// #130 - Respect trailing whitespace in words if directly preceding a hard break.
     /// So right-aligned wrapped on 2 lines `Foo bar` will look different to `Foo \nbar`.
     #[test]
-    fn include_spaces_in_layout_width_preceeded_hard_break() {
+    fn include_spaces_in_layout_width_preceded_hard_break() {
         // should wrap due to width bound
         let glyphs_no_newline = Layout::default()
             .h_align(HorizontalAlign::Right)
@@ -1010,7 +1010,7 @@ mod layout_test {
             .collect();
         assert_eq!(y_positions.len(), 2, "{y_positions:?}");
 
-        // explict wrap should include the space in the layout width,
+        // explicit wrap should include the space in the layout width,
         // so the explicit newline `F` should be to the left of the no_newline `F`.
         let newline_f = &glyphs_newline[0];
         let no_newline_f = &glyphs_no_newline[0];
@@ -1022,10 +1022,10 @@ mod layout_test {
         );
     }
 
-    /// #130 - Respect trailing whitespace in words if directly preceeding end-of-glyphs.
+    /// #130 - Respect trailing whitespace in words if directly preceding end-of-glyphs.
     /// So right-aligned `Foo ` will look different to `Foo`.
     #[test]
-    fn include_spaces_in_layout_width_preceeded_end() {
+    fn include_spaces_in_layout_width_preceded_end() {
         let glyphs_no_newline = Layout::default()
             .h_align(HorizontalAlign::Right)
             .calculate_glyphs(

--- a/layout/src/lib.rs
+++ b/layout/src/lib.rs
@@ -101,7 +101,7 @@ pub trait GlyphPositioner: Hash {
     /// Recalculate a glyph sequence after a change.
     ///
     /// The default implementation simply calls `calculate_glyphs` so must be implemented
-    /// to provide benefits as such benefits are spefic to the internal layout logic.
+    /// to provide benefits as such benefits are specific to the internal layout logic.
     fn recalculate_glyphs<F, S, P>(
         &self,
         previous: P,


### PR DESCRIPTION
Found via `typos --hidden --format brief`