### PR TITLE
Upgrade to twox-hash 2.0

### DIFF
--- a/glyph-brush/Cargo.toml
+++ b/glyph-brush/Cargo.toml
@@ -14,12 +14,13 @@ glyph_brush_draw_cache = { version = "0.1.1", path = "../draw-cache" }
 glyph_brush_layout = { version = "0.2.3", path = "../layout" }
 ordered-float = "4"
 rustc-hash = "2"
-twox-hash = { version = "1.6.1", default-features = false }
+twox-hash = { version = "2.0.0", default-features = false, features = ["xxhash64"] }
 
-# enable twox-hash rand/std everywhere except wasm
+# enable twox-hash rand everywhere except wasm
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies.twox-hash]
-version = "1.6.1"
-features = ["std"]
+version = "2.0.0"
+default-features = false
+features = ["random"]
 
 [dev-dependencies]
 approx = "0.5"

--- a/glyph-brush/src/lib.rs
+++ b/glyph-brush/src/lib.rs
@@ -45,10 +45,10 @@ use glyph_brush_layout::ab_glyph::*;
 
 /// A "practically collision free" `Section` hasher
 #[cfg(not(target_arch = "wasm32"))]
-pub type DefaultSectionHasher = twox_hash::RandomXxHashBuilder;
+pub type DefaultSectionHasher = twox_hash::xxhash64::RandomState;
 // Work around for rand issues in wasm #61
 #[cfg(target_arch = "wasm32")]
-pub type DefaultSectionHasher = std::hash::BuildHasherDefault<twox_hash::XxHash>;
+pub type DefaultSectionHasher = std::hash::BuildHasherDefault<twox_hash::XxHash64>;
 
 #[test]
 fn default_section_hasher() {


### PR DESCRIPTION
Thanks for using my crate!

Note that version 2.0 increases the MSRV to Rust 1.81. I understand if you don't want to upgrade right away, but hopefully this PR will be useful when you do.

I'm opening these PRs for the top users of twox-hash and have no current plans to become a consistent contributor to this specific repository; please feel free to rewrite the commit as appropriate for your project's requirements.